### PR TITLE
Support for slices of ints, bools and strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ import (
 )
 
 type config struct {
-	Home         string `env:"HOME"`
-	Port         int    `env:"PORT" envDefault:"3000"`
-	IsProduction bool   `env:"PRODUCTION"`
+	Home         string   `env:"HOME"`
+	Port         int      `env:"PORT" envDefault:"3000"`
+	IsProduction bool     `env:"PRODUCTION"`
+	Hosts        []string `env:"HOSTS" envSeparator:":"`
 }
 
 func main() {
@@ -47,13 +48,20 @@ func main() {
 You can run it like this:
 
 ```sh
-$ PRODUCTION=true go run examples/first.go
-{/tmp/fakehome 3000 true}
+$ PRODUCTION=true HOSTS="host1:host2:host3" go run examples/first.go
+{/tmp/fakehome 3000 false [host1 host2 host3]}
 ```
 
 ## Supported types and defaults
 
-Currently we only support `string`, `bool` and `int`.
+The library has support for the following types:
+
+* `string`
+* `int`
+* `bool`
+* `[]string`
+* `[]int`
+* `[]bool`
 
 If you set the `envDefault` tag for something, this value will be used in the
 case of absence of it in the environment. If you don't do that AND the
@@ -61,3 +69,4 @@ environment variable is also not set, the zero-value
 of the type will be used: empty for `string`s, `false` for `bool`s
 and `0` for `int`s.
 
+By default, slice types will split the environment value on `,`; you can change this behavior by setting the `envSeparator` tag.

--- a/env.go
+++ b/env.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // ErrNotAStructPtr is returned if you pass something that is not a pointer to a
@@ -13,6 +14,14 @@ var ErrNotAStructPtr = errors.New("Expected a pointer to a Struct")
 
 // ErrUnsuportedType if the struct field type is not supported by env
 var ErrUnsuportedType = errors.New("Type is not supported")
+
+// ErrUnsupportedSliceType if the slice element type is not supported by env
+var ErrUnsuportedSliceType = errors.New("Unsupported slice type")
+
+// Friendly names for reflect types
+var sliceOfInts = reflect.TypeOf([]int(nil))
+var sliceOfStrings = reflect.TypeOf([]string(nil))
+var sliceOfBools = reflect.TypeOf([]bool(nil))
 
 // Parse parses a struct containing `env` tags and loads its values from
 // environment variables.
@@ -35,7 +44,7 @@ func doParse(ref reflect.Value, val interface{}) error {
 		if value == "" {
 			continue
 		}
-		if err := set(ref.Field(i), value); err != nil {
+		if err := set(ref.Field(i), refType.Field(i), value); err != nil {
 			return err
 		}
 	}
@@ -55,8 +64,11 @@ func getOr(key, defaultValue string) string {
 	return defaultValue
 }
 
-func set(field reflect.Value, value string) error {
+func set(field reflect.Value, refType reflect.StructField, value string) error {
 	switch field.Kind() {
+	case reflect.Slice:
+		separator := refType.Tag.Get("envSeparator")
+		return handleSlice(field, value, separator)
 	case reflect.String:
 		field.SetString(value)
 	case reflect.Bool:
@@ -75,4 +87,59 @@ func set(field reflect.Value, value string) error {
 		return ErrUnsuportedType
 	}
 	return nil
+}
+
+func handleSlice(field reflect.Value, value, separator string) error {
+	if separator == "" {
+		separator = ","
+	}
+
+	splitData := strings.Split(value, separator)
+
+	switch field.Type() {
+	case sliceOfStrings:
+		field.Set(reflect.ValueOf(splitData))
+	case sliceOfInts:
+		intData, err := parseInts(splitData)
+		if err != nil {
+			return err
+		}
+		field.Set(reflect.ValueOf(intData))
+	case sliceOfBools:
+		boolData, err := parseBools(splitData)
+		if err != nil {
+			return err
+		}
+		field.Set(reflect.ValueOf(boolData))
+	default:
+		return ErrUnsuportedSliceType
+	}
+	return nil
+}
+
+func parseInts(data []string) ([]int, error) {
+	intSlice := make([]int, 0)
+
+	for _, v := range data {
+		intValue, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		intSlice = append(intSlice, int(intValue))
+	}
+	return intSlice, nil
+}
+
+func parseBools(data []string) ([]bool, error) {
+	boolSlice := make([]bool, 0)
+
+	for _, v := range data {
+		bvalue, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, err
+		}
+
+		boolSlice = append(boolSlice, bvalue)
+	}
+	return boolSlice, nil
 }

--- a/env.go
+++ b/env.go
@@ -118,7 +118,7 @@ func handleSlice(field reflect.Value, value, separator string) error {
 }
 
 func parseInts(data []string) ([]int, error) {
-	intSlice := make([]int, 0)
+	var intSlice []int
 
 	for _, v := range data {
 		intValue, err := strconv.ParseInt(v, 10, 32)
@@ -131,7 +131,7 @@ func parseInts(data []string) ([]int, error) {
 }
 
 func parseBools(data []string) ([]bool, error) {
-	boolSlice := make([]bool, 0)
+	var boolSlice []bool
 
 	for _, v := range data {
 		bvalue, err := strconv.ParseBool(v)

--- a/env_test.go
+++ b/env_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/caarlos0/env"
+	"github.com/dselans/env"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,22 +14,39 @@ type Config struct {
 	Other       bool   `env:"othervar"`
 	Port        int    `env:"PORT"`
 	NotAnEnv    string
-	DatabaseURL string `env:"DATABASE_URL" envDefault:"postgres://localhost:5432/db"`
+	DatabaseURL string   `env:"DATABASE_URL" envDefault:"postgres://localhost:5432/db"`
+	Strings     []string `env:"STRINGS"`
+	SepStrings  []string `env:"SEPSTRINGS" envSeparator:":"`
+	Numbers     []int    `env:"NUMBERS"`
+	Bools       []bool   `env:"BOOLS"`
 }
 
 func TestParsesEnv(t *testing.T) {
 	os.Setenv("somevar", "somevalue")
 	os.Setenv("othervar", "true")
 	os.Setenv("PORT", "8080")
+	os.Setenv("STRINGS", "string1,string2,string3")
+	os.Setenv("SEPSTRINGS", "string1:string2:string3")
+	os.Setenv("NUMBERS", "1,2,3,4")
+	os.Setenv("BOOLS", "t,TRUE,0,1")
+
 	defer os.Setenv("somevar", "")
 	defer os.Setenv("othervar", "")
 	defer os.Setenv("PORT", "")
+	defer os.Setenv("STRINGS", "")
+	defer os.Setenv("SEPSTRINGS", "")
+	defer os.Setenv("NUMBERS", "")
+	defer os.Setenv("BOOLS", "")
 
 	cfg := Config{}
 	assert.NoError(t, env.Parse(&cfg))
 	assert.Equal(t, "somevalue", cfg.Some)
 	assert.Equal(t, true, cfg.Other)
 	assert.Equal(t, 8080, cfg.Port)
+	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.Strings)
+	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.SepStrings)
+	assert.Equal(t, []int{1, 2, 3, 4}, cfg.Numbers)
+	assert.Equal(t, []bool{true, true, false, true}, cfg.Bools)
 }
 
 func TestEmptyVars(t *testing.T) {
@@ -66,6 +83,16 @@ func TestInvalidInt(t *testing.T) {
 	assert.Error(t, env.Parse(&cfg))
 }
 
+func TestInvalidBoolsSlice(t *testing.T) {
+	type config struct {
+		BadBools []bool `env:"BADBOOLS"`
+	}
+
+	os.Setenv("BADBOOLS", "t,f,TRUE,faaaalse")
+	cfg := &config{}
+	assert.Error(t, env.Parse(cfg))
+}
+
 func TestParsesDefaultConfig(t *testing.T) {
 	cfg := Config{}
 	assert.NoError(t, env.Parse(&cfg))
@@ -85,6 +112,30 @@ func TestParseStructWithInvalidFieldKind(t *testing.T) {
 	os.Setenv("BLAH", "10")
 	cfg := config{}
 	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestUnsupportedSliceType(t *testing.T) {
+	type config struct {
+		WontWork []map[int]int `env:"WONTWORK"`
+	}
+
+	os.Setenv("WONTWORK", "1,2,3")
+	defer os.Setenv("WONTWORK", "")
+
+	cfg := &config{}
+	assert.Error(t, env.Parse(cfg))
+}
+
+func TestBadSeparator(t *testing.T) {
+	type config struct {
+		WontWork []int `env:"WONTWORK" envSeparator:":"`
+	}
+
+	cfg := &config{}
+	os.Setenv("WONTWORK", "1,2,3,4")
+	defer os.Setenv("WONTWORK", "")
+
+	assert.Error(t, env.Parse(cfg))
 }
 
 func ExampleParse() {

--- a/env_test.go
+++ b/env_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dselans/env"
+	"github.com/caarlos0/env"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/first.go
+++ b/examples/first.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 
-	"github.com/caarlos0/env"
+	"github.com/dselans/env"
 )
 
 type config struct {
-	Home         string `env:"HOME"`
-	Port         int    `env:"PORT" default:"3000"`
-	IsProduction bool   `env:"PRODUCTION"`
+	Home         string   `env:"HOME"`
+	Port         int      `env:"PORT" default:"3000"`
+	IsProduction bool     `env:"PRODUCTION"`
+	Hosts        []string `env:"HOSTS" envSeparator:":"`
 }
 
 func main() {

--- a/examples/first.go
+++ b/examples/first.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/dselans/env"
+	"github.com/caarlos0/env"
 )
 
 type config struct {


### PR DESCRIPTION
Hey there - nice lib!

This PR adds support for []string, []int and []bool types and allows you to set a separator via the struct tag.

```
dselans:env dselans$ go test ./... -cover -v
=== RUN   TestParsesEnv
--- PASS: TestParsesEnv (0.00s)
=== RUN   TestEmptyVars
--- PASS: TestEmptyVars (0.00s)
=== RUN   TestPassAnInvalidPtr
--- PASS: TestPassAnInvalidPtr (0.00s)
=== RUN   TestPassReference
--- PASS: TestPassReference (0.00s)
=== RUN   TestInvalidBool
--- PASS: TestInvalidBool (0.00s)
=== RUN   TestInvalidInt
--- PASS: TestInvalidInt (0.00s)
=== RUN   TestInvalidBoolsSlice
--- PASS: TestInvalidBoolsSlice (0.00s)
=== RUN   TestParsesDefaultConfig
--- PASS: TestParsesDefaultConfig (0.00s)
=== RUN   TestParseStructWithoutEnvTag
--- PASS: TestParseStructWithoutEnvTag (0.00s)
=== RUN   TestParseStructWithInvalidFieldKind
--- PASS: TestParseStructWithInvalidFieldKind (0.00s)
=== RUN   TestUnsupportedSliceType
--- PASS: TestUnsupportedSliceType (0.00s)
=== RUN   TestBadSeparator
--- PASS: TestBadSeparator (0.00s)
=== RUN   ExampleParse
--- PASS: ExampleParse (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/dselans/env	0.008s	coverage: 100.0% of statements
?   	github.com/dselans/env/examples	[no test files]
```

P.S. Will have to update the import lines in env_test.go and the example to point to your repo!