### PR TITLE
Introduce the env tag option 'required'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,20 @@ of the type will be used: empty for `string`s, `false` for `bool`s
 and `0` for `int`s.
 
 By default, slice types will split the environment value on `,`; you can change this behavior by setting the `envSeparator` tag.
+
+## Required fields
+
+The `env` tag option `required` (e.g., `env:"tagKey,required"`) can be added 
+to ensure that some environment variable is set.  In the example above, 
+an error is returned if the `config` struct is changed to:
+
+
+```go
+type config struct {
+    Home         string   `env:"HOME"`
+    Port         int      `env:"PORT" envDefault:"3000"`
+    IsProduction bool     `env:"PRODUCTION"`
+    Hosts        []string `env:"HOSTS" envSeparator:":"`
+    SecretKey    string   `env:"SECRET_KEY,required"`
+}
+```


### PR DESCRIPTION
Fields with the `env` tag set can now also include an option string,
similar to the json package: e.g., `env:"VAR_NAME,required"`.
This commit adds support for the "required" option.

The option parsing logic is somewhat primitive.  Only a single option at
a time is respected, and only either no option or the `required` option.

Parse returns an error if the `required` option is set for the env tag and
the corresponding environment variable is empty.

If a new tag such as `envRequired:"true"` is preferred over the current option implementation, we can refactor and update the PR.