### PR TITLE
add ability to use env variables that are prefixed with a string

### DIFF
--- a/env.go
+++ b/env.go
@@ -44,7 +44,7 @@ func Parse(v interface{}) error {
 
 // Parse parses a struct containing `env` tags and loads its values from
 // environment variables that start with the prefix `prefix`
-func ParseUsingPrefix(v interface{}, prefix string) error{
+func ParseUsingPrefix(v interface{}, prefix string) error {
 	envVariablePrefix = prefix
 	return Parse(v)
 }

--- a/env.go
+++ b/env.go
@@ -124,7 +124,7 @@ func getRequired(key string) (string, error) {
 
 func getOr(key, defaultValue string, prefix string) string {
 	if &prefix != nil && prefix != "" {
-		key = prefix + "_" + key
+		key = prefix + key
 	}
 	value, ok := os.LookupEnv(key)
 	if ok {

--- a/env.go
+++ b/env.go
@@ -42,7 +42,7 @@ func Parse(v interface{}) error {
 	return doParse(ref)
 }
 
-// Parse parses a struct containing `env` tags and loads its values from
+// ParseUsingPrefix parses a struct containing `env` tags and loads its values from
 // environment variables that start with the prefix `prefix`
 func ParseUsingPrefix(v interface{}, prefix string) error {
 	envVariablePrefix = prefix

--- a/env_test.go
+++ b/env_test.go
@@ -253,7 +253,7 @@ func TestGettingEnvVarsUsingAPrefix(t *testing.T) {
 	os.Setenv("PREFIX_somevar", "aVarWithPrefix")
 	os.Setenv("PREFIX_othervar", "t")
 	cfg := Config{}
-	assert.NoError(t, env.ParseUsingPrefix(&cfg, "PREFIX"))
+	assert.NoError(t, env.ParseUsingPrefix(&cfg, "PREFIX_"))
 	assert.Equal(t, "aVarWithPrefix", cfg.Some)
 	assert.Equal(t, true, cfg.Other)
 
@@ -291,7 +291,7 @@ func ExampleParseUsingPrefix() {
 	}
 	os.Setenv("MYPREFIX_HOME", "/tmp/fakehome")
 	cfg := config{}
-	env.ParseUsingPrefix(&cfg, "MYPREFIX")
+	env.ParseUsingPrefix(&cfg, "MYPREFIX_")
 	fmt.Println(cfg)
 	// Output: {/tmp/fakehome 3000 false}
 }

--- a/env_test.go
+++ b/env_test.go
@@ -46,6 +46,7 @@ func TestParsesEnv(t *testing.T) {
 	os.Setenv("SEPSTRINGS", "string1:string2:string3")
 	os.Setenv("NUMBERS", "1,2,3,4")
 	os.Setenv("NUMBERS64", "1,2,2147483640,-2147483640")
+	os.Setenv("INT64", "999")
 	os.Setenv("BOOLS", "t,TRUE,0,1")
 	os.Setenv("DURATION", "1s")
 	os.Setenv("FLOAT32", "3.40282346638528859811704183484516925440e+38")
@@ -66,6 +67,7 @@ func TestParsesEnv(t *testing.T) {
 	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.SepStrings)
 	assert.Equal(t, []int{1, 2, 3, 4}, cfg.Numbers)
 	assert.Equal(t, []int64{1, 2, 2147483640, -2147483640}, cfg.Numbers64)
+	assert.Equal(t, int64(999), cfg.Int64)
 	assert.Equal(t, []bool{true, true, false, true}, cfg.Bools)
 	d, _ := time.ParseDuration("1s")
 	assert.Equal(t, d, cfg.Duration)
@@ -134,17 +136,33 @@ func TestInvalidInt(t *testing.T) {
 }
 
 func TestInvalidInt64(t *testing.T) {
-	os.Setenv("INT64", "999")
+	os.Setenv("INT64", "notAnInt")
 	defer os.Clearenv()
 
 	cfg := Config{}
 	env.Parse(&cfg)
 
-	assert.Equal(t, int64(999), cfg.Int64)
+	assert.Error(t, env.Parse(&cfg))
 }
 
 func TestInvalidUint(t *testing.T) {
 	os.Setenv("UINTVAL", "-44")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidFloat32(t *testing.T) {
+	os.Setenv("FLOAT32", "notfloat")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidFloat64(t *testing.T) {
+	os.Setenv("FLOAT64", "notfloat")
 	defer os.Clearenv()
 
 	cfg := Config{}

--- a/env_test.go
+++ b/env_test.go
@@ -248,6 +248,28 @@ func TestErrorOptionNotRecognized(t *testing.T) {
 
 }
 
+func TestGettingEnvVarsUsingAPrefix(t *testing.T) {
+
+	os.Setenv("PREFIX_somevar", "aVarWithPrefix")
+	os.Setenv("PREFIX_othervar", "t")
+	cfg := Config{}
+	assert.NoError(t, env.ParseUsingPrefix(&cfg, "PREFIX"))
+	assert.Equal(t, "aVarWithPrefix", cfg.Some)
+	assert.Equal(t, true, cfg.Other)
+
+}
+
+func TestGettingEnvVarsWithAnEmptyPrefix(t *testing.T) {
+
+	os.Setenv("somevar", "aVarWithPrefix")
+	os.Setenv("othervar", "t")
+	cfg := Config{}
+	assert.NoError(t, env.ParseUsingPrefix(&cfg, ""))
+	assert.Equal(t, "aVarWithPrefix", cfg.Some)
+	assert.Equal(t, true, cfg.Other)
+
+}
+
 func ExampleParse() {
 	type config struct {
 		Home         string `env:"HOME"`
@@ -257,6 +279,19 @@ func ExampleParse() {
 	os.Setenv("HOME", "/tmp/fakehome")
 	cfg := config{}
 	env.Parse(&cfg)
+	fmt.Println(cfg)
+	// Output: {/tmp/fakehome 3000 false}
+}
+
+func ExampleParseUsingPrefix() {
+	type config struct {
+		Home         string `env:"HOME"`
+		Port         int    `env:"PORT" envDefault:"3000"`
+		IsProduction bool   `env:"PRODUCTION"`
+	}
+	os.Setenv("MYPREFIX_HOME", "/tmp/fakehome")
+	cfg := config{}
+	env.ParseUsingPrefix(&cfg, "MYPREFIX")
 	fmt.Println(cfg)
 	// Output: {/tmp/fakehome 3000 false}
 }

--- a/env_test.go
+++ b/env_test.go
@@ -21,6 +21,7 @@ type Config struct {
 	SepStrings  []string      `env:"SEPSTRINGS" envSeparator:":"`
 	Numbers     []int         `env:"NUMBERS"`
 	Numbers64   []int64       `env:"NUMBERS64"`
+	Int64       int64         `env:"INT64"`
 	Bools       []bool        `env:"BOOLS"`
 	Duration    time.Duration `env:"DURATION"`
 	Float32     float32       `env:"FLOAT32"`
@@ -130,6 +131,16 @@ func TestInvalidInt(t *testing.T) {
 
 	cfg := Config{}
 	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidInt64(t *testing.T) {
+	os.Setenv("INT64", "999")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	env.Parse(&cfg)
+
+	assert.Equal(t, int64(999), cfg.Int64)
 }
 
 func TestInvalidUint(t *testing.T) {


### PR DESCRIPTION
I'm new to golang but wanted to have a play with some "real" code.
I won't be offended if this PR is rejected, I'm mainly after some feedback about how it could / should be done better etc.

This PR adds the ability to prefix environment variables with a string, this would enable two apps to be running side by side and only require changing the prefix that each instance is looking for.

I have also added a test for some previously untested code.

the following two examples would return the same"

```
$HOME=/some/home
env.Parse(&cfg)

$PREFIX_HOME = /some/home
env.ParseUsingPrefix(&cfg, "PREFIX_")
```