### PR TITLE
Introduce support for custom parsers + url.URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ type config struct {
 	IsProduction bool          `env:"PRODUCTION"`
 	Hosts        []string      `env:"HOSTS" envSeparator:":"`
 	Duration     time.Duration `env:"DURATION"`
+	HostURL      url.URL       `env:"HostURL" envDefault:"https://google.com"`
 }
 
 func main() {
@@ -57,7 +58,7 @@ $ PRODUCTION=true HOSTS="host1:host2:host3" DURATION=1s go run examples/first.go
 
 ## Supported types and defaults
 
-The library has support for the following types:
+The library has built-in support for the following types:
 
 * `string`
 * `int`
@@ -71,6 +72,9 @@ The library has support for the following types:
 * `[]bool`
 * `[]float32`
 * `[]float64`
+* `time.Duration`
+* `url.URL`
+* .. or define a [custom parser func](#custom-parser-funcs) for any other type
 
 If you set the `envDefault` tag for something, this value will be used in the
 case of absence of it in the environment. If you don't do that AND the
@@ -79,6 +83,17 @@ of the type will be used: empty for `string`s, `false` for `bool`s
 and `0` for `int`s.
 
 By default, slice types will split the environment value on `,`; you can change this behavior by setting the `envSeparator` tag.
+
+## Custom Parser Funcs
+
+If you have a type that is not supported out of the box by the lib, you are able
+to define and pass custom parsers (and their associated `reflect.Type`) to the
+`env.ParseWithFuncs()` function.
+
+In addition to accepting the struct ref (same as `Parse()`), this function also
+accepts a `env.CustomParsers` arg that under the covers is a `map[reflect.Type]env.ParserFunc`.
+
+To see what this looks like in practice, take a look at the [commented block in the example](https://github.com/caarlos0/env/blob/master/examples/first.go#L37-L41).
 
 ## Required fields
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ type config struct {
 	IsProduction bool          `env:"PRODUCTION"`
 	Hosts        []string      `env:"HOSTS" envSeparator:":"`
 	Duration     time.Duration `env:"DURATION"`
-	HostURL      url.URL       `env:"HostURL" envDefault:"https://google.com"`
 }
 
 func main() {
@@ -73,8 +72,7 @@ The library has built-in support for the following types:
 * `[]float32`
 * `[]float64`
 * `time.Duration`
-* `url.URL`
-* .. or define a [custom parser func](#custom-parser-funcs) for any other type
+* .. or use/define a [custom parser func](#custom-parser-funcs) for any other type
 
 If you set the `envDefault` tag for something, this value will be used in the
 case of absence of it in the environment. If you don't do that AND the
@@ -87,13 +85,16 @@ By default, slice types will split the environment value on `,`; you can change 
 ## Custom Parser Funcs
 
 If you have a type that is not supported out of the box by the lib, you are able
-to define and pass custom parsers (and their associated `reflect.Type`) to the
+to use (or define) and pass custom parsers (and their associated `reflect.Type`) to the
 `env.ParseWithFuncs()` function.
 
-In addition to accepting the struct ref (same as `Parse()`), this function also
+In addition to accepting a struct pointer (same as `Parse()`), this function also
 accepts a `env.CustomParsers` arg that under the covers is a `map[reflect.Type]env.ParserFunc`.
 
-To see what this looks like in practice, take a look at the [commented block in the example](https://github.com/caarlos0/env/blob/master/examples/first.go#L37-L41).
+To see what this looks like in practice, take a look at the [commented block in the example](https://github.com/caarlos0/env/blob/master/examples/first.go#L35-L39).
+
+`env` also ships with some pre-built custom parser funcs for common types. You
+can check them out [here](parsers/).
 
 ## Required fields
 

--- a/env.go
+++ b/env.go
@@ -2,6 +2,8 @@ package env
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -26,6 +28,12 @@ var (
 	sliceOfFloat64s = reflect.TypeOf([]float64(nil))
 )
 
+// CustomParsers is a friendly name for the type that `ParseWithFuncs()` accepts
+type CustomParsers map[reflect.Type]ParserFunc
+
+// ParserFunc defines the signature of a function that can be used within `CustomParsers`
+type ParserFunc func(v string) (interface{}, error)
+
 // Parse parses a struct containing `env` tags and loads its values from
 // environment variables.
 func Parse(v interface{}) error {
@@ -37,10 +45,24 @@ func Parse(v interface{}) error {
 	if ref.Kind() != reflect.Struct {
 		return ErrNotAStructPtr
 	}
-	return doParse(ref)
+	return doParse(ref, make(map[reflect.Type]ParserFunc, 0))
 }
 
-func doParse(ref reflect.Value) error {
+// ParseWithFuncs is the same as `Parse` except it also allows the user to pass
+// in custom parsers.
+func ParseWithFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc) error {
+	ptrRef := reflect.ValueOf(v)
+	if ptrRef.Kind() != reflect.Ptr {
+		return ErrNotAStructPtr
+	}
+	ref := ptrRef.Elem()
+	if ref.Kind() != reflect.Struct {
+		return ErrNotAStructPtr
+	}
+	return doParse(ref, funcMap)
+}
+
+func doParse(ref reflect.Value, funcMap CustomParsers) error {
 	refType := ref.Type()
 	var errorList []string
 
@@ -60,7 +82,7 @@ func doParse(ref reflect.Value) error {
 		if value == "" {
 			continue
 		}
-		if err := set(ref.Field(i), refType.Field(i), value); err != nil {
+		if err := set(ref.Field(i), refType.Field(i), value, funcMap); err != nil {
 			errorList = append(errorList, err.Error())
 			continue
 		}
@@ -121,7 +143,7 @@ func getOr(key, defaultValue string) string {
 	return defaultValue
 }
 
-func set(field reflect.Value, refType reflect.StructField, value string) error {
+func set(field reflect.Value, refType reflect.StructField, value string, funcMap CustomParsers) error {
 	switch field.Kind() {
 	case reflect.Slice:
 		separator := refType.Tag.Get("envSeparator")
@@ -172,9 +194,42 @@ func set(field reflect.Value, refType reflect.StructField, value string) error {
 			}
 			field.SetInt(intValue)
 		}
+	case reflect.Struct:
+		return handleStruct(field, refType, value, funcMap)
 	default:
 		return ErrUnsupportedType
 	}
+	return nil
+}
+
+func handleStruct(field reflect.Value, refType reflect.StructField, value string, funcMap CustomParsers) error {
+	switch refType.Type.String() {
+	case "url.URL":
+		u, err := url.Parse(value)
+		if err != nil {
+			return fmt.Errorf("Unable to complete URL parse: %v", err)
+		}
+
+		field.Set(reflect.ValueOf(*u))
+	default:
+		// Does the custom parser func map contain this type?
+		parserFunc, ok := funcMap[field.Type()]
+		if !ok {
+			// Map does not contain a custom parser for this type
+			return ErrUnsupportedType
+		}
+
+		// Call on the custom parser func
+		data, err := parserFunc(value)
+		if err != nil {
+			return fmt.Errorf("Custom parser error: %v", err)
+		}
+
+		// Set the field to the data returned by the customer parser func
+		rv := reflect.ValueOf(data)
+		field.Set(rv)
+	}
+
 	return nil
 }
 

--- a/env_test.go
+++ b/env_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"reflect"
 	"testing"
@@ -31,8 +30,6 @@ type Config struct {
 	Float64     float64       `env:"FLOAT64"`
 	Float32s    []float32     `env:"FLOAT32S"`
 	Float64s    []float64     `env:"FLOAT64S"`
-	TestURL1    url.URL       `env:"TEST_URL1"`
-	TestURL2    url.URL       `env:"TEST_URL2" envDefault:"https://google.com"`
 }
 
 type ParentStruct struct {
@@ -60,7 +57,6 @@ func TestParsesEnv(t *testing.T) {
 	os.Setenv("FLOAT32S", "1.0,2.0,3.0")
 	os.Setenv("FLOAT64S", "1.0,2.0,3.0")
 	os.Setenv("UINTVAL", "44")
-	os.Setenv("TEST_URL1", "https://foo.bar")
 
 	defer os.Clearenv()
 
@@ -83,8 +79,6 @@ func TestParsesEnv(t *testing.T) {
 	assert.Equal(t, f64, cfg.Float64)
 	assert.Equal(t, []float32{float32(1.0), float32(2.0), float32(3.0)}, cfg.Float32s)
 	assert.Equal(t, []float64{float64(1.0), float64(2.0), float64(3.0)}, cfg.Float64s)
-	assert.Equal(t, "https://foo.bar", cfg.TestURL1.String())
-	assert.Equal(t, "https://google.com", cfg.TestURL2.String())
 }
 
 func TestParsesEnvInner(t *testing.T) {
@@ -237,20 +231,6 @@ func TestErrorRequiredNotSet(t *testing.T) {
 	assert.Error(t, env.Parse(cfg))
 }
 
-func TestNotURLStruct(t *testing.T) {
-	type config struct {
-		Foo http.Client `env:"FOO"`
-	}
-
-	os.Setenv("FOO", "foo")
-
-	cfg := &config{}
-	err := env.Parse(cfg)
-
-	assert.Error(t, err)
-	assert.Equal(t, env.ErrUnsupportedType, err)
-}
-
 func TestCustomParser(t *testing.T) {
 	type foo struct {
 		name string
@@ -314,19 +294,18 @@ func TestCustomParserError(t *testing.T) {
 	assert.Equal(t, err.Error(), "Custom parser error: something broke")
 }
 
-func TestParseBadURL(t *testing.T) {
+func TestUnsupportedStructType(t *testing.T) {
 	type config struct {
-		MyURL url.URL `env:"MY_URL"`
+		Foo http.Client `env:"FOO"`
 	}
 
-	os.Setenv("MY_URL", "!@#$%^&*()-_+=")
+	os.Setenv("FOO", "foo")
 
 	cfg := &config{}
 	err := env.Parse(cfg)
 
 	assert.Error(t, err)
-	assert.Equal(t, cfg.MyURL.String(), "", "URL should not be set when parse fails")
-	assert.Contains(t, err.Error(), "invalid URL escape")
+	assert.Equal(t, env.ErrUnsupportedType, err)
 }
 func TestEmptyOption(t *testing.T) {
 	type config struct {

--- a/env_test.go
+++ b/env_test.go
@@ -275,6 +275,20 @@ func TestCustomParser(t *testing.T) {
 	assert.Equal(t, cfg.Var.name, "test")
 }
 
+func TestParseWithFuncsNoPtr(t *testing.T) {
+	type foo struct{}
+	err := env.ParseWithFuncs(foo{}, nil)
+	assert.Error(t, err)
+	assert.Equal(t, err, env.ErrNotAStructPtr)
+}
+
+func TestParseWithFuncsInvalidType(t *testing.T) {
+	var c int
+	err := env.ParseWithFuncs(&c, nil)
+	assert.Error(t, err)
+	assert.Equal(t, err, env.ErrNotAStructPtr)
+}
+
 func TestCustomParserError(t *testing.T) {
 	type foo struct {
 		name string

--- a/examples/first.go
+++ b/examples/first.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"net/url"
 	"strings"
 	"time"
 
@@ -16,7 +15,6 @@ type config struct {
 	IsProduction bool          `env:"PRODUCTION"`
 	Hosts        []string      `env:"HOSTS" envSeparator:":"`
 	Duration     time.Duration `env:"DURATION"`
-	ExampleURL   url.URL       `env:"EXAMPLE_URL" envDefault:"https://google.com"`
 	ExampleFoo   Foo           `env:"EXAMPLE_FOO"`
 }
 

--- a/examples/first.go
+++ b/examples/first.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/caarlos0/env"
@@ -13,13 +16,35 @@ type config struct {
 	IsProduction bool          `env:"PRODUCTION"`
 	Hosts        []string      `env:"HOSTS" envSeparator:":"`
 	Duration     time.Duration `env:"DURATION"`
+	ExampleURL   url.URL       `env:"EXAMPLE_URL" envDefault:"https://google.com"`
+	ExampleFoo   Foo           `env:"EXAMPLE_FOO"`
+}
+
+type Foo struct {
+	Name string
 }
 
 func main() {
 	cfg := config{}
-	err := env.Parse(&cfg)
-	if err != nil {
-		fmt.Printf("%+v\n", err)
+
+	// Parse for built-in types
+	if err := env.Parse(&cfg); err != nil {
+		log.Fatal("Unable to parse envs: ", err)
 	}
+
+	// OR w/ a custom parser for `Foo`
+	//
+	// if err := env.ParseWithFuncs(&cfg, env.CustomParsers{
+	// 	reflect.TypeOf(Foo{}): fooParser,
+	// }); err != nil {
+	// 	log.Fatal("Unable to parse envs: ", err)
+	// }
+
 	fmt.Printf("%+v\n", cfg)
+}
+
+func fooParser(value string) (interface{}, error) {
+	return Foo{
+		Name: strings.ToUpper(value),
+	}, nil
 }

--- a/parsers/README.md
+++ b/parsers/README.md
@@ -1,0 +1,35 @@
+parsers
+=======
+This directory contains pre-built, custom parsers that can be used with `env.ParseWithFuncs`
+to facilitate the parsing of envs that are not basic types.
+
+Example Usage:
+
+```golang
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/caarlos0/env"
+	"github.com/caarlos0/env/parsers"
+)
+
+type config struct {
+	ExampleURL url.URL `env:"EXAMPLE_URL" envDefault:"https://google.com"`
+}
+
+func main() {
+	cfg := config{}
+
+	if err := env.ParseWithFuncs(&cfg, env.CustomParsers{
+		parsers.URLType: parsers.URLFunc,
+	}); err != nil {
+		log.Fatal("Unable to parse envs: ", err)
+	}
+
+	fmt.Printf("Scheme: %v Host: %v\n", cfg.ExampleURL.Scheme, cfg.ExampleURL.Host)
+}
+```

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -1,0 +1,23 @@
+// Package parsers contains custom parser funcs for common, non-built-in types
+package parsers
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+)
+
+var (
+	// URLType is a helper var that represents the `reflect.Type`` of `url.URL`
+	URLType = reflect.TypeOf(url.URL{})
+)
+
+// URLFunc is a basic parser for the url.URL type that should be used with `env.ParseWithFuncs()`
+func URLFunc(v string) (interface{}, error) {
+	u, err := url.Parse(v)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to complete URL parse: %v", err)
+	}
+
+	return *u, nil
+}


### PR DESCRIPTION
Previous PR was based on an outdated fork. Woops! This should be better.
 
- Added support for `url.URL`
- Added support for custom parsers via `ParseWithFuncs()` (new func to avoid breaking backwards compat)
- Updated documentation
- Updated tests (100% cov for all new functionality)

@caarlos0 can you take a peek at this?