### PR TITLE
Expand support for custom parsers to non-struct types

### DIFF
--- a/env.go
+++ b/env.go
@@ -196,7 +196,15 @@ func set(field reflect.Value, refType reflect.StructField, value string, funcMap
 	case reflect.Struct:
 		return handleStruct(field, refType, value, funcMap)
 	default:
-		return ErrUnsupportedType
+		parserFunc, ok := funcMap[refType.Type]
+		if !ok {
+			return ErrUnsupportedType
+		}
+		val, err := parserFunc(value)
+		if err != nil {
+			return err
+		}
+		field.Set(reflect.ValueOf(val))
 	}
 	return nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -361,7 +361,7 @@ func TestCustomParserBasicUnsupported(t *testing.T) {
 		Const ConstT `env:"CONST_VAL"`
 	}
 
-	set := ConstT(123)
+	exp := ConstT(123)
 	os.Setenv("CONST_VAL", fmt.Sprintf("%d", exp))
 
 	cfg := &config{}

--- a/env_test.go
+++ b/env_test.go
@@ -330,18 +330,11 @@ func TypeCustomParserBasicInvalid(t *testing.T) {
 		Const ConstT `env:"CONST_VAL"`
 	}
 
-	envVal := "invalid"
+	os.Setenv("CONST_VAL", "foobar")
 
-	_, expErr := strconv.Atoi(envVal)
-	os.Setenv("CONST_VAL", envVal)
-
-	customParserFunc := func(v string) (interface{}, error) {
-		i, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, err
-		}
-		r := ConstT(i)
-		return r, nil
+	expErr := errors.New("Random error")
+	customParserFunc := func(_ string) (interface{}, error) {
+		return nil, expErr
 	}
 
 	cfg := &config{}
@@ -351,7 +344,7 @@ func TypeCustomParserBasicInvalid(t *testing.T) {
 
 	assert.Empty(t, cfg.Const)
 	assert.Error(t, err)
-	assert.Equal(t, expErr.Error(), err.Error())
+	assert.Equal(t, expErr, err)
 }
 
 func TestCustomParserBasicUnsupported(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/caarl0s/env"
+	"github.com/caarlos0/env"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/env_test.go
+++ b/env_test.go
@@ -296,7 +296,7 @@ func TestCustomParserError(t *testing.T) {
 }
 
 func TestCustomParserBasicType(t *testing.T) {
-	type ConstT int
+	type ConstT int32
 
 	type config struct {
 		Const ConstT `env:"CONST_VAL"`
@@ -324,7 +324,7 @@ func TestCustomParserBasicType(t *testing.T) {
 }
 
 func TypeCustomParserBasicInvalid(t *testing.T) {
-	type ConstT int
+	type ConstT int32
 
 	type config struct {
 		Const ConstT `env:"CONST_VAL"`
@@ -355,7 +355,7 @@ func TypeCustomParserBasicInvalid(t *testing.T) {
 }
 
 func TestCustomParserBasicUnsupported(t *testing.T) {
-	type ConstT int
+	type ConstT int32
 
 	type config struct {
 		Const ConstT `env:"CONST_VAL"`
@@ -365,9 +365,9 @@ func TestCustomParserBasicUnsupported(t *testing.T) {
 	os.Setenv("CONST_VAL", fmt.Sprintf("%d", exp))
 
 	cfg := &config{}
-	err := env.ParseWithFuncs(cfg, map[reflect.Type]env.ParserFunc{})
+	err := env.Parse(cfg)
 
-	assert.Empty(t, cfg.Const)
+	assert.Zero(t, cfg.Const)
 	assert.Error(t, err)
 	assert.Equal(t, env.ErrUnsupportedType, err)
 }


### PR DESCRIPTION
Sometimes you end up with having types in your config that are essentially `int` or `string`. An example of this would be log levels. I'm using logrus, and would like to be able to set `LOG_LEVEL=debug`, and map it directly on to my config struct:

```go

type Config struct {
    LogLevel logrus.Level `env:"LOG_LEVEL" envDefault:"debug"`
}

func logLevelParser(v string) (interface{}, error) {
    return logrus.ParseLevel(v)
}

func Get() (*Config, error) {
    c := &Config{}
    parsers := env.CustomParsers{
        reflect.TypeOf(logrus.GetLevel()): logLevelParser,
    }
    if err := env.ParseWithFuncs(c, parsers); err != nil {
        return nil, err
    }
    return c, nil
}
```

I like the custom parser support, but I think it would be even better still if we could add parser functions for basic types (ie non-struct types). Hence the PR.

It's a small change, but I think quite a useful addition to the package. I've added 1 test covering this case. Let me know if more tests are required.