### PR TITLE
support uint64 and []uint64

### DIFF
--- a/env.go
+++ b/env.go
@@ -194,6 +194,12 @@ func set(field reflect.Value, refType reflect.StructField, value string, funcMap
 			}
 			field.SetInt(intValue)
 		}
+	case reflect.Uint64:
+		uintValue, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		field.SetUint(uintValue)
 	case reflect.Struct:
 		return handleStruct(field, refType, value, funcMap)
 	default:

--- a/env.go
+++ b/env.go
@@ -21,6 +21,7 @@ var (
 	// Friendly names for reflect types
 	sliceOfInts      = reflect.TypeOf([]int(nil))
 	sliceOfInt64s    = reflect.TypeOf([]int64(nil))
+	sliceOfUint64s   = reflect.TypeOf([]uint64(nil))
 	sliceOfStrings   = reflect.TypeOf([]string(nil))
 	sliceOfBools     = reflect.TypeOf([]bool(nil))
 	sliceOfFloat32s  = reflect.TypeOf([]float32(nil))
@@ -251,7 +252,12 @@ func handleSlice(field reflect.Value, value, separator string) error {
 			return err
 		}
 		field.Set(reflect.ValueOf(int64Data))
-
+	case sliceOfUint64s:
+		uint64Data, err := parseUint64s(splitData)
+		if err != nil {
+			return err
+		}
+		field.Set(reflect.ValueOf(uint64Data))
 	case sliceOfFloat32s:
 		data, err := parseFloat32s(splitData)
 		if err != nil {
@@ -306,6 +312,19 @@ func parseInt64s(data []string) ([]int64, error) {
 		intSlice = append(intSlice, int64(intValue))
 	}
 	return intSlice, nil
+}
+
+func parseUint64s(data []string) ([]uint64, error) {
+	var uintSlice []uint64
+
+	for _, v := range data {
+		uintValue, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		uintSlice = append(uintSlice, uint64(uintValue))
+	}
+	return uintSlice, nil
 }
 
 func parseFloat32s(data []string) ([]float32, error) {

--- a/env_test.go
+++ b/env_test.go
@@ -25,6 +25,7 @@ type Config struct {
 	SepStrings  []string        `env:"SEPSTRINGS" envSeparator:":"`
 	Numbers     []int           `env:"NUMBERS"`
 	Numbers64   []int64         `env:"NUMBERS64"`
+	UNumbers64  []uint64        `env:"UNUMBERS64"`
 	Bools       []bool          `env:"BOOLS"`
 	Duration    time.Duration   `env:"DURATION"`
 	Float32     float32         `env:"FLOAT32"`
@@ -52,6 +53,7 @@ func TestParsesEnv(t *testing.T) {
 	os.Setenv("SEPSTRINGS", "string1:string2:string3")
 	os.Setenv("NUMBERS", "1,2,3,4")
 	os.Setenv("NUMBERS64", "1,2,2147483640,-2147483640")
+	os.Setenv("UNUMBERS64", "1,2,214748364011,9147483641")
 	os.Setenv("BOOLS", "t,TRUE,0,1")
 	os.Setenv("DURATION", "1s")
 	os.Setenv("FLOAT32", "3.40282346638528859811704183484516925440e+38")
@@ -75,6 +77,7 @@ func TestParsesEnv(t *testing.T) {
 	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.SepStrings)
 	assert.Equal(t, []int{1, 2, 3, 4}, cfg.Numbers)
 	assert.Equal(t, []int64{1, 2, 2147483640, -2147483640}, cfg.Numbers64)
+	assert.Equal(t, []uint64{1, 2, 214748364011, 9147483641}, cfg.UNumbers64)
 	assert.Equal(t, []bool{true, true, false, true}, cfg.Bools)
 	d1, _ := time.ParseDuration("1s")
 	assert.Equal(t, d1, cfg.Duration)

--- a/env_test.go
+++ b/env_test.go
@@ -18,6 +18,7 @@ type Config struct {
 	Other       bool   `env:"othervar"`
 	Port        int    `env:"PORT"`
 	UintVal     uint   `env:"UINTVAL"`
+	Uint64Val   uint64 `env:"UINT64VAL"`
 	NotAnEnv    string
 	DatabaseURL string          `env:"DATABASE_URL" envDefault:"postgres://localhost:5432/db"`
 	Strings     []string        `env:"STRINGS"`
@@ -58,6 +59,7 @@ func TestParsesEnv(t *testing.T) {
 	os.Setenv("FLOAT32S", "1.0,2.0,3.0")
 	os.Setenv("FLOAT64S", "1.0,2.0,3.0")
 	os.Setenv("UINTVAL", "44")
+	os.Setenv("UINT64VAL", "6464")
 	os.Setenv("DURATIONS", "1s,2s,3s")
 
 	defer os.Clearenv()
@@ -68,6 +70,7 @@ func TestParsesEnv(t *testing.T) {
 	assert.Equal(t, true, cfg.Other)
 	assert.Equal(t, 8080, cfg.Port)
 	assert.Equal(t, uint(44), cfg.UintVal)
+	assert.Equal(t, uint64(6464), cfg.Uint64Val)
 	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.Strings)
 	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.SepStrings)
 	assert.Equal(t, []int{1, 2, 3, 4}, cfg.Numbers)
@@ -111,6 +114,7 @@ func TestEmptyVars(t *testing.T) {
 	assert.Equal(t, false, cfg.Other)
 	assert.Equal(t, 0, cfg.Port)
 	assert.Equal(t, uint(0), cfg.UintVal)
+	assert.Equal(t, uint64(0), cfg.Uint64Val)
 	assert.Equal(t, 0, len(cfg.Strings))
 	assert.Equal(t, 0, len(cfg.SepStrings))
 	assert.Equal(t, 0, len(cfg.Numbers))

--- a/env_test.go
+++ b/env_test.go
@@ -44,6 +44,7 @@ type ParentStruct struct {
 
 type InnerStruct struct {
 	Inner string `env:"innervar"`
+	Number uint  `env:"innernum"`
 }
 
 func TestParsesEnv(t *testing.T) {
@@ -111,6 +112,15 @@ func TestParsesEnvInnerNil(t *testing.T) {
 	defer os.Clearenv()
 	cfg := ParentStruct{}
 	assert.NoError(t, env.Parse(&cfg))
+}
+
+func TestParsesEnvInnerInvalid(t *testing.T) {
+	os.Setenv("innernum", "-547")
+	defer os.Clearenv()
+	cfg := ParentStruct{
+		InnerStruct: &InnerStruct{},
+	}
+	assert.Error(t, env.Parse(&cfg))
 }
 
 func TestEmptyVars(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -158,6 +158,70 @@ func TestInvalidUint(t *testing.T) {
 	assert.Error(t, env.Parse(&cfg))
 }
 
+func TestInvalidFloat32(t *testing.T) {
+	os.Setenv("FLOAT32", "AAA")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidFloat64(t *testing.T) {
+	os.Setenv("FLOAT64", "AAA")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidUint64(t *testing.T) {
+	os.Setenv("UINT64VAL", "AAA")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidInt64Slice(t *testing.T) {
+	type config struct {
+		BadFloats []int64 `env:"BADINTS"`
+	}
+
+	os.Setenv("BADINTS", "A,2,3")
+	cfg := &config{}
+	assert.Error(t, env.Parse(cfg))
+}
+
+func TestInvalidUInt64Slice(t *testing.T) {
+	type config struct {
+		BadFloats []uint64 `env:"BADINTS"`
+	}
+
+	os.Setenv("BADFLOATS", "A,2,3")
+	cfg := &config{}
+	assert.Error(t, env.Parse(cfg))
+}
+
+func TestInvalidFloat32Slice(t *testing.T) {
+	type config struct {
+		BadFloats []float32 `env:"BADFLOATS"`
+	}
+
+	os.Setenv("BADFLOATS", "A,2.0,3.0")
+	cfg := &config{}
+	assert.Error(t, env.Parse(cfg))
+}
+
+func TestInvalidFloat64Slice(t *testing.T) {
+	type config struct {
+		BadFloats []float64 `env:"BADFLOATS"`
+	}
+
+	os.Setenv("BADFLOATS", "A,2.0,3.0")
+	cfg := &config{}
+	assert.Error(t, env.Parse(cfg))
+}
+
 func TestInvalidBoolsSlice(t *testing.T) {
 	type config struct {
 		BadBools []bool `env:"BADBOOLS"`

--- a/env_test.go
+++ b/env_test.go
@@ -17,6 +17,7 @@ type Config struct {
 	Some        string `env:"somevar"`
 	Other       bool   `env:"othervar"`
 	Port        int    `env:"PORT"`
+	Int64Val    int64  `env:"INT64VAL"`
 	UintVal     uint   `env:"UINTVAL"`
 	Uint64Val   uint64 `env:"UINT64VAL"`
 	NotAnEnv    string
@@ -62,6 +63,7 @@ func TestParsesEnv(t *testing.T) {
 	os.Setenv("FLOAT64S", "1.0,2.0,3.0")
 	os.Setenv("UINTVAL", "44")
 	os.Setenv("UINT64VAL", "6464")
+	os.Setenv("INT64VAL", "-7575")
 	os.Setenv("DURATIONS", "1s,2s,3s")
 
 	defer os.Clearenv()
@@ -72,6 +74,7 @@ func TestParsesEnv(t *testing.T) {
 	assert.Equal(t, true, cfg.Other)
 	assert.Equal(t, 8080, cfg.Port)
 	assert.Equal(t, uint(44), cfg.UintVal)
+	assert.Equal(t, int64(-7575), cfg.Int64Val)
 	assert.Equal(t, uint64(6464), cfg.Uint64Val)
 	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.Strings)
 	assert.Equal(t, []string{"string1", "string2", "string3"}, cfg.SepStrings)
@@ -118,6 +121,7 @@ func TestEmptyVars(t *testing.T) {
 	assert.Equal(t, 0, cfg.Port)
 	assert.Equal(t, uint(0), cfg.UintVal)
 	assert.Equal(t, uint64(0), cfg.Uint64Val)
+	assert.Equal(t, int64(0), cfg.Int64Val)
 	assert.Equal(t, 0, len(cfg.Strings))
 	assert.Equal(t, 0, len(cfg.SepStrings))
 	assert.Equal(t, 0, len(cfg.Numbers))
@@ -176,6 +180,14 @@ func TestInvalidFloat64(t *testing.T) {
 
 func TestInvalidUint64(t *testing.T) {
 	os.Setenv("UINT64VAL", "AAA")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidInt64(t *testing.T) {
+	os.Setenv("INT64VAL", "AAA")
 	defer os.Clearenv()
 
 	cfg := Config{}


### PR DESCRIPTION
We can't add custom parsers, since unint64 is a primitive and not a struct, this PR adds support for parsing uint64 and slices of uint64.