### PR TITLE
Add time.Duration slice support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ The library has built-in support for the following types:
 * `bool`
 * `float32`
 * `float64`
+* `time.Duration`
 * `[]string`
 * `[]int`
 * `[]bool`
 * `[]float32`
 * `[]float64`
-* `time.Duration`
+* `[]time.Duration`
 * .. or use/define a [custom parser func](#custom-parser-funcs) for any other type
 
 If you set the `envDefault` tag for something, this value will be used in the

--- a/env.go
+++ b/env.go
@@ -19,12 +19,13 @@ var (
 	// ErrUnsupportedSliceType if the slice element type is not supported by env
 	ErrUnsupportedSliceType = errors.New("Unsupported slice type")
 	// Friendly names for reflect types
-	sliceOfInts     = reflect.TypeOf([]int(nil))
-	sliceOfInt64s   = reflect.TypeOf([]int64(nil))
-	sliceOfStrings  = reflect.TypeOf([]string(nil))
-	sliceOfBools    = reflect.TypeOf([]bool(nil))
-	sliceOfFloat32s = reflect.TypeOf([]float32(nil))
-	sliceOfFloat64s = reflect.TypeOf([]float64(nil))
+	sliceOfInts      = reflect.TypeOf([]int(nil))
+	sliceOfInt64s    = reflect.TypeOf([]int64(nil))
+	sliceOfStrings   = reflect.TypeOf([]string(nil))
+	sliceOfBools     = reflect.TypeOf([]bool(nil))
+	sliceOfFloat32s  = reflect.TypeOf([]float32(nil))
+	sliceOfFloat64s  = reflect.TypeOf([]float64(nil))
+	sliceOfDurations = reflect.TypeOf([]time.Duration(nil))
 )
 
 // CustomParsers is a friendly name for the type that `ParseWithFuncs()` accepts
@@ -263,6 +264,12 @@ func handleSlice(field reflect.Value, value, separator string) error {
 			return err
 		}
 		field.Set(reflect.ValueOf(boolData))
+	case sliceOfDurations:
+		durationData, err := parseDurations(splitData)
+		if err != nil {
+			return err
+		}
+		field.Set(reflect.ValueOf(durationData))
 	default:
 		return ErrUnsupportedSliceType
 	}
@@ -270,7 +277,7 @@ func handleSlice(field reflect.Value, value, separator string) error {
 }
 
 func parseInts(data []string) ([]int, error) {
-	var intSlice []int
+	intSlice := make([]int, 0, len(data))
 
 	for _, v := range data {
 		intValue, err := strconv.ParseInt(v, 10, 32)
@@ -283,7 +290,7 @@ func parseInts(data []string) ([]int, error) {
 }
 
 func parseInt64s(data []string) ([]int64, error) {
-	var intSlice []int64
+	intSlice := make([]int64, 0, len(data))
 
 	for _, v := range data {
 		intValue, err := strconv.ParseInt(v, 10, 64)
@@ -296,7 +303,7 @@ func parseInt64s(data []string) ([]int64, error) {
 }
 
 func parseFloat32s(data []string) ([]float32, error) {
-	var float32Slice []float32
+	float32Slice := make([]float32, 0, len(data))
 
 	for _, v := range data {
 		data, err := strconv.ParseFloat(v, 32)
@@ -309,7 +316,7 @@ func parseFloat32s(data []string) ([]float32, error) {
 }
 
 func parseFloat64s(data []string) ([]float64, error) {
-	var float64Slice []float64
+	float64Slice := make([]float64, 0, len(data))
 
 	for _, v := range data {
 		data, err := strconv.ParseFloat(v, 64)
@@ -322,7 +329,7 @@ func parseFloat64s(data []string) ([]float64, error) {
 }
 
 func parseBools(data []string) ([]bool, error) {
-	var boolSlice []bool
+	boolSlice := make([]bool, 0, len(data))
 
 	for _, v := range data {
 		bvalue, err := strconv.ParseBool(v)
@@ -333,4 +340,18 @@ func parseBools(data []string) ([]bool, error) {
 		boolSlice = append(boolSlice, bvalue)
 	}
 	return boolSlice, nil
+}
+
+func parseDurations(data []string) ([]time.Duration, error) {
+	durationSlice := make([]time.Duration, 0, len(data))
+
+	for _, v := range data {
+		dvalue, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, err
+		}
+
+		durationSlice = append(durationSlice, dvalue)
+	}
+	return durationSlice, nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -19,17 +19,18 @@ type Config struct {
 	Port        int    `env:"PORT"`
 	UintVal     uint   `env:"UINTVAL"`
 	NotAnEnv    string
-	DatabaseURL string        `env:"DATABASE_URL" envDefault:"postgres://localhost:5432/db"`
-	Strings     []string      `env:"STRINGS"`
-	SepStrings  []string      `env:"SEPSTRINGS" envSeparator:":"`
-	Numbers     []int         `env:"NUMBERS"`
-	Numbers64   []int64       `env:"NUMBERS64"`
-	Bools       []bool        `env:"BOOLS"`
-	Duration    time.Duration `env:"DURATION"`
-	Float32     float32       `env:"FLOAT32"`
-	Float64     float64       `env:"FLOAT64"`
-	Float32s    []float32     `env:"FLOAT32S"`
-	Float64s    []float64     `env:"FLOAT64S"`
+	DatabaseURL string          `env:"DATABASE_URL" envDefault:"postgres://localhost:5432/db"`
+	Strings     []string        `env:"STRINGS"`
+	SepStrings  []string        `env:"SEPSTRINGS" envSeparator:":"`
+	Numbers     []int           `env:"NUMBERS"`
+	Numbers64   []int64         `env:"NUMBERS64"`
+	Bools       []bool          `env:"BOOLS"`
+	Duration    time.Duration   `env:"DURATION"`
+	Float32     float32         `env:"FLOAT32"`
+	Float64     float64         `env:"FLOAT64"`
+	Float32s    []float32       `env:"FLOAT32S"`
+	Float64s    []float64       `env:"FLOAT64S"`
+	Durations   []time.Duration `env:"DURATIONS"`
 }
 
 type ParentStruct struct {
@@ -57,6 +58,7 @@ func TestParsesEnv(t *testing.T) {
 	os.Setenv("FLOAT32S", "1.0,2.0,3.0")
 	os.Setenv("FLOAT64S", "1.0,2.0,3.0")
 	os.Setenv("UINTVAL", "44")
+	os.Setenv("DURATIONS", "1s,2s,3s")
 
 	defer os.Clearenv()
 
@@ -71,14 +73,17 @@ func TestParsesEnv(t *testing.T) {
 	assert.Equal(t, []int{1, 2, 3, 4}, cfg.Numbers)
 	assert.Equal(t, []int64{1, 2, 2147483640, -2147483640}, cfg.Numbers64)
 	assert.Equal(t, []bool{true, true, false, true}, cfg.Bools)
-	d, _ := time.ParseDuration("1s")
-	assert.Equal(t, d, cfg.Duration)
+	d1, _ := time.ParseDuration("1s")
+	assert.Equal(t, d1, cfg.Duration)
 	f32 := float32(3.40282346638528859811704183484516925440e+38)
 	assert.Equal(t, f32, cfg.Float32)
 	f64 := float64(1.797693134862315708145274237317043567981e+308)
 	assert.Equal(t, f64, cfg.Float64)
 	assert.Equal(t, []float32{float32(1.0), float32(2.0), float32(3.0)}, cfg.Float32s)
 	assert.Equal(t, []float64{float64(1.0), float64(2.0), float64(3.0)}, cfg.Float64s)
+	d2, _ := time.ParseDuration("2s")
+	d3, _ := time.ParseDuration("3s")
+	assert.Equal(t, []time.Duration{d1, d2, d3}, cfg.Durations)
 }
 
 func TestParsesEnvInner(t *testing.T) {
@@ -158,6 +163,14 @@ func TestInvalidBoolsSlice(t *testing.T) {
 
 func TestInvalidDuration(t *testing.T) {
 	os.Setenv("DURATION", "should-be-a-valid-duration")
+	defer os.Clearenv()
+
+	cfg := Config{}
+	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestInvalidDurations(t *testing.T) {
+	os.Setenv("DURATIONS", "1s,contains-an-invalid-duration,3s")
 	defer os.Clearenv()
 
 	cfg := Config{}


### PR DESCRIPTION
This PR contains a few minor changes:

* Added support for time.Duration slices
* Slices are allocated in one call using make + capacity, instead of
incremental allocations through the built-in append mechanism

Arguably the latter is micro-optimisation, but seeing as it doesn't add
complexity, and is more efficient, there isn't really an argument
against it.