### PR TITLE
Adding a general-purpose, optional zero-overhead per-field convenience callback:

### DIFF
--- a/env.go
+++ b/env.go
@@ -18,6 +18,9 @@ var (
 	ErrUnsupportedType = errors.New("Type is not supported")
 	// ErrUnsupportedSliceType if the slice element type is not supported by env
 	ErrUnsupportedSliceType = errors.New("Unsupported slice type")
+	// OnEnvVarSet is an optional convenience callback, such as for logging purposes.
+	// If not nil, it's called after successfully setting the given field from the given value.
+	OnEnvVarSet func(reflect.StructField, string)
 	// Friendly names for reflect types
 	sliceOfInts      = reflect.TypeOf([]int(nil))
 	sliceOfInt64s    = reflect.TypeOf([]int64(nil))
@@ -88,6 +91,9 @@ func doParse(ref reflect.Value, funcMap CustomParsers) error {
 		if err := set(refField, refTypeField, value, funcMap); err != nil {
 			errorList = append(errorList, err.Error())
 			continue
+		}
+		if OnEnvVarSet != nil {
+			OnEnvVarSet(refTypeField, value)
 		}
 	}
 	if len(errorList) == 0 {

--- a/env.go
+++ b/env.go
@@ -68,14 +68,16 @@ func doParse(ref reflect.Value, funcMap CustomParsers) error {
 	var errorList []string
 
 	for i := 0; i < refType.NumField(); i++ {
-		if reflect.Ptr == ref.Field(i).Kind() && !ref.Field(i).IsNil() && ref.Field(i).CanSet() {
-			err := Parse(ref.Field(i).Interface())
+		refField := ref.Field(i)
+		if reflect.Ptr == refField.Kind() && !refField.IsNil() && refField.CanSet() {
+			err := Parse(refField.Interface())
 			if nil != err {
 				return err
 			}
 			continue
 		}
-		value, err := get(refType.Field(i))
+		refTypeField := refType.Field(i)
+		value, err := get(refTypeField)
 		if err != nil {
 			errorList = append(errorList, err.Error())
 			continue
@@ -83,7 +85,7 @@ func doParse(ref reflect.Value, funcMap CustomParsers) error {
 		if value == "" {
 			continue
 		}
-		if err := set(ref.Field(i), refType.Field(i), value, funcMap); err != nil {
+		if err := set(refField, refTypeField, value, funcMap); err != nil {
 			errorList = append(errorList, err.Error())
 			continue
 		}


### PR DESCRIPTION
--- working in a project right now where we want to log the env-vars on-service-startup, and also present them in a "service self-description API endpoint".

Since this is already relying on your neat `env` package, it would be ugly to recreate your existing `reflect` traversals for our purposes here. With this new optional general-purpose callback `OnEnvVarSet(field, value)` anyone can easily achieve such (or similar, or other) custom-requirements with `env`  =)

The first commit in here is not pertinent, simply some minor hygiene. The second commit is the meat of this PR, as per above.