### PR TITLE
Fix uint64 alias custom parser

### DIFF
--- a/env.go
+++ b/env.go
@@ -153,6 +153,18 @@ func getOr(key, defaultValue string) string {
 }
 
 func set(field reflect.Value, refType reflect.StructField, value string, funcMap CustomParsers) error {
+	// use custom parser if configured for this type
+	parserFunc, ok := funcMap[refType.Type]
+	if ok {
+		val, err := parserFunc(value)
+		if err != nil {
+			return fmt.Errorf("Custom parser error: %v", err)
+		}
+		field.Set(reflect.ValueOf(val))
+		return nil
+	}
+
+	// fall back to built-in parsers
 	switch field.Kind() {
 	case reflect.Slice:
 		separator := refType.Tag.Get("envSeparator")
@@ -210,15 +222,7 @@ func set(field reflect.Value, refType reflect.StructField, value string, funcMap
 		}
 		field.SetUint(uintValue)
 	default:
-		parserFunc, ok := funcMap[refType.Type]
-		if !ok {
-			return handleTextUnmarshaler(field, value)
-		}
-		val, err := parserFunc(value)
-		if err != nil {
-			return fmt.Errorf("custom parser: %v", err)
-		}
-		field.Set(reflect.ValueOf(val))
+		return handleTextUnmarshaler(field, value)
 	}
 	return nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -425,7 +425,7 @@ func TestCustomParserError(t *testing.T) {
 
 	assert.Empty(t, cfg.Var.name, "Var.name should not be filled out when parse errors")
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "custom parser: something broke")
+	assert.Equal(t, "Custom parser error: something broke", err.Error())
 }
 
 func TestCustomParserBasicType(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -512,6 +512,34 @@ func TypeCustomParserBasicInvalid(t *testing.T) {
 	assert.Equal(t, expErr, err)
 }
 
+func TestCustomParserNotCalledForNonAlias(t *testing.T) {
+	type T uint64
+	type U uint64
+
+	type config struct {
+		Val   uint64 `env:"VAL" envDefault:"33"`
+		Other U      `env:"OTHER" envDefault:"44"`
+	}
+
+	tParserCalled := false
+
+	tParser := func(value string) (interface{}, error) {
+		tParserCalled = true
+		return T(99), nil
+	}
+
+	cfg := config{}
+
+	err := env.ParseWithFuncs(&cfg, env.CustomParsers{
+		reflect.TypeOf(T(0)): tParser,
+	})
+
+	assert.False(t, tParserCalled, "tParser should not have been called")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(33), cfg.Val)
+	assert.Equal(t, U(44), cfg.Other)
+}
+
 func TestCustomParserBasicUnsupported(t *testing.T) {
 	type ConstT int32
 


### PR DESCRIPTION
Needed to check for custom parsers before matching against basic types, since aliases of those types were matching in the switch, causing the custom parser to be ignored.