### PR TITLE
Fix bug when parsing env variables set and empty

### DIFF
--- a/env.go
+++ b/env.go
@@ -138,15 +138,14 @@ func parseKeyForOption(key string) (string, []string) {
 }
 
 func getRequired(key string) (string, error) {
-	if value, ok := os.LookupEnv(key); ok {
+	if value, ok := os.LookupEnv(key); ok && len(value) > 0 {
 		return value, nil
 	}
 	return "", fmt.Errorf("required environment variable %q is not set", key)
 }
 
 func getOr(key, defaultValue string) string {
-	value, ok := os.LookupEnv(key)
-	if ok {
+	if value, ok := os.LookupEnv(key); ok && len(value) > 0 {
 		return value
 	}
 	return defaultValue

--- a/env_test.go
+++ b/env_test.go
@@ -303,6 +303,20 @@ func TestParsesDefaultConfig(t *testing.T) {
 	assert.Equal(t, "postgres://localhost:5432/db", cfg.DatabaseURL)
 }
 
+func TestParsesDefaultConfigSetEmpty(t *testing.T) {
+	os.Setenv("PORT", "")
+	defer os.Clearenv()
+
+	type config struct {
+		Port int `env:"PORT" envDefault:"3000"`
+	}
+
+	cfg := &config{}
+
+	assert.NoError(t, env.Parse(cfg))
+	assert.Equal(t, 3000, cfg.Port)
+}
+
 func TestParseStructWithoutEnvTag(t *testing.T) {
 	cfg := Config{}
 	assert.NoError(t, env.Parse(&cfg))
@@ -360,6 +374,17 @@ func TestErrorRequiredNotSet(t *testing.T) {
 		IsRequired string `env:"IS_REQUIRED,required"`
 	}
 
+	cfg := &config{}
+	assert.Error(t, env.Parse(cfg))
+}
+
+func TestErrorRequiredSetEmpty(t *testing.T) {
+	os.Setenv("PORT", "")
+	defer os.Clearenv()
+
+	type config struct {
+		Port int `env:"PORT,required"`
+	}
 	cfg := &config{}
 	assert.Error(t, env.Parse(cfg))
 }


### PR DESCRIPTION
the following bugs were found:

* default bug fixed: when environment variable does not exists, default value will be chosen... But when environment variable exists and it is empty, that empty string will be chosen.

* required bug fixed: when environment variable does not exists, in error will be thrown... But when environment variable exists and it is empty, no error will be throw.