### PR TITLE
Add expand option to support variable expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ type config struct {
 	IsProduction bool          `env:"PRODUCTION"`
 	Hosts        []string      `env:"HOSTS" envSeparator:":"`
 	Duration     time.Duration `env:"DURATION"`
+	TempFolder   string        `env:"TEMP_FOLDER" envDefault:"${HOME}/tmp" envExpand:"True"`
 }
 
 func main() {
@@ -82,6 +83,11 @@ of the type will be used: empty for `string`s, `false` for `bool`s
 and `0` for `int`s.
 
 By default, slice types will split the environment value on `,`; you can change this behavior by setting the `envSeparator` tag.
+
+
+If you set the `envExpand` tag, ${var} or $var in the string will be replaced according to the values of the current environment variables.
+
+
 
 ## Custom Parser Funcs
 

--- a/env.go
+++ b/env.go
@@ -114,6 +114,11 @@ func get(field reflect.StructField) (string, error) {
 	defaultValue := field.Tag.Get("envDefault")
 	val = getOr(key, defaultValue)
 
+	expandVar := field.Tag.Get("envExpand")
+	if strings.ToLower(expandVar) == "true" {
+		val = os.ExpandEnv(val)
+	}
+
 	if len(opts) > 0 {
 		for _, opt := range opts {
 			// The only option supported is "required".

--- a/env_test.go
+++ b/env_test.go
@@ -364,6 +364,34 @@ func TestErrorRequiredNotSet(t *testing.T) {
 	assert.Error(t, env.Parse(cfg))
 }
 
+func TestParseExpandOption(t *testing.T) {
+	type config struct {
+		Host        string `env:"HOST" envDefault:"localhost"`
+		Port        int    `env:"PORT" envDefault:"3000" envExpand:"True"`
+		SecretKey   string `env:"SECRET_KEY" envExpand:"True"`
+		ExpandKey   string `env:"EXPAND_KEY"`
+		CompoundKey string `env:"HOST_PORT" envDefault:"${HOST}:${PORT}" envExpand:"True"`
+		Default     string `env:"DEFAULT" envDefault:"def1"  envExpand:"True"`
+	}
+	defer os.Clearenv()
+
+	os.Setenv("HOST", "localhost")
+	os.Setenv("PORT", "3000")
+	os.Setenv("EXPAND_KEY", "qwerty12345")
+	os.Setenv("SECRET_KEY", "${EXPAND_KEY}")
+
+	cfg := config{}
+	err := env.Parse(&cfg)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, 3000, cfg.Port)
+	assert.Equal(t, "qwerty12345", cfg.SecretKey)
+	assert.Equal(t, "qwerty12345", cfg.ExpandKey)
+	assert.Equal(t, "localhost:3000", cfg.CompoundKey)
+	assert.Equal(t, "def1", cfg.Default)
+}
+
 func TestCustomParser(t *testing.T) {
 	type foo struct {
 		name string


### PR DESCRIPTION
We are wanting to reference environment variables from existing variables.  I've added this as an `expand` option but could be part of the default behavior if that's desired.  This will look for the `${VAR}` pattern and replace with the appropriate variable if found. 