### PR TITLE
Option to add a prefix in front of each environment variable.

### DIFF
--- a/env.go
+++ b/env.go
@@ -31,6 +31,9 @@ var (
 	sliceOfFloat32s  = reflect.TypeOf([]float32(nil))
 	sliceOfFloat64s  = reflect.TypeOf([]float64(nil))
 	sliceOfDurations = reflect.TypeOf([]time.Duration(nil))
+
+	// EnvPrefix should be set to the environment prefix, i.e. PREFIX_
+	EnvPrefix = ""
 )
 
 // CustomParsers is a friendly name for the type that `ParseWithFuncs()` accepts
@@ -143,14 +146,14 @@ func parseKeyForOption(key string) (string, []string) {
 }
 
 func getRequired(key string) (string, error) {
-	if value, ok := os.LookupEnv(key); ok {
+	if value, ok := os.LookupEnv(EnvPrefix + key); ok {
 		return value, nil
 	}
 	return "", fmt.Errorf("required environment variable %q is not set", key)
 }
 
 func getOr(key, defaultValue string) string {
-	value, ok := os.LookupEnv(key)
+	value, ok := os.LookupEnv(EnvPrefix + key)
 	if ok {
 		return value
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -571,6 +571,27 @@ func TestTextUnmarshalerError(t *testing.T) {
 	assert.Error(t, env.Parse(cfg))
 }
 
+func TestParseEnvPrefix(t *testing.T) {
+	type config struct {
+		Foo int `env:"FOO"`
+	}
+
+	cfg := config{}
+
+	env.EnvPrefix = "PREFIX_"
+
+	os.Setenv("PREFIX_FOO", "10")
+	assert.NoError(t, env.Parse(&cfg))
+	assert.Equal(t, 10, cfg.Foo)
+
+	cfg.Foo = 0
+	env.EnvPrefix = ""
+
+	os.Setenv("FOO", "10")
+	assert.NoError(t, env.Parse(&cfg))
+	assert.Equal(t, 10, cfg.Foo)
+}
+
 func ExampleParse() {
 	type config struct {
 		Home         string `env:"HOME"`


### PR DESCRIPTION
Surgical and safe.

```env.EnvPrefix = "PREFIX_"

type config struct {
	Home         string        `env:"HOME"`
} 
cfg := config{}
env.Parse(&cfg)

os.Getenv("PREFIX_HOME")```