### PR TITLE
AutoExportFields turns Field into FIELD, no `env` needed.

### DIFF
--- a/env.go
+++ b/env.go
@@ -31,6 +31,8 @@ var (
 	sliceOfFloat32s  = reflect.TypeOf([]float32(nil))
 	sliceOfFloat64s  = reflect.TypeOf([]float64(nil))
 	sliceOfDurations = reflect.TypeOf([]time.Duration(nil))
+	// AutoExportFields turns Field into FIELD, no env needed.
+	AutoExportFields bool
 )
 
 // CustomParsers is a friendly name for the type that `ParseWithFuncs()` accepts
@@ -110,6 +112,10 @@ func get(field reflect.StructField) (string, error) {
 	)
 
 	key, opts := parseKeyForOption(field.Tag.Get("env"))
+
+	if AutoExportFields && key == "" {
+		key = strings.ToUpper(field.Name)
+	}
 
 	defaultValue := field.Tag.Get("envDefault")
 	val = getOr(key, defaultValue)

--- a/env_test.go
+++ b/env_test.go
@@ -571,6 +571,23 @@ func TestTextUnmarshalerError(t *testing.T) {
 	assert.Error(t, env.Parse(cfg))
 }
 
+func TestAutoName(t *testing.T) {
+	type config struct {
+		Named   int `env:"NAMED"`
+		Unnamed int
+	}
+	cfg := &config{}
+	os.Setenv("NAMED", "10")
+	os.Setenv("UNNAMED", "20")
+
+	env.AutoExportFields = true
+	assert.NoError(t, env.Parse(cfg))
+	assert.Equal(t, cfg.Named, 10)
+	assert.Equal(t, cfg.Unnamed, 20)
+
+	env.AutoExportFields = false
+}
+
 func ExampleParse() {
 	type config struct {
 		Home         string `env:"HOME"`


### PR DESCRIPTION
Just a simple `key = strings.ToUpper(field.Name).`