### PR TITLE
Adds nested struct support

### DIFF
--- a/env.go
+++ b/env.go
@@ -80,6 +80,13 @@ func doParse(ref reflect.Value, funcMap CustomParsers) error {
 			}
 			continue
 		}
+		if reflect.Struct == refField.Kind() {
+			err := doParse(refField, funcMap)
+			if nil != err {
+				errorList = append(errorList, err.Error())
+			}
+			continue
+		}
 		refTypeField := refType.Field(i)
 		value, err := get(refTypeField)
 		if err != nil {

--- a/env_test.go
+++ b/env_test.go
@@ -67,6 +67,13 @@ type InnerStruct struct {
 	Number uint   `env:"innernum"`
 }
 
+type ForNestedStruct struct {
+	NestedStruct
+}
+type NestedStruct struct {
+	NestedVar string `env:"nestedvar"`
+}
+
 func TestParsesEnv(t *testing.T) {
 	os.Setenv("somevar", "somevalue")
 	os.Setenv("othervar", "true")
@@ -149,6 +156,14 @@ func TestParsesEnvInnerInvalid(t *testing.T) {
 		InnerStruct: &InnerStruct{},
 	}
 	assert.Error(t, env.Parse(&cfg))
+}
+
+func TestParsesEnvNested(t *testing.T) {
+	os.Setenv("nestedvar", "somenestedvalue")
+	defer os.Clearenv()
+	var cfg ForNestedStruct
+	assert.NoError(t, env.Parse(&cfg))
+	assert.Equal(t, "somenestedvalue", cfg.NestedVar)
 }
 
 func TestEmptyVars(t *testing.T) {


### PR DESCRIPTION
This commit adds nested struct support.

It allows to decompose config on sub-configs with their own interfaces

```go
type Config struct {
	NestedConfig
}
type NestedConfig struct {
	NestedVar string `env:"nestedvar"`
}
```

```
var cfg Config
err := env.Parse(&cfg);
```