### PR TITLE
feat: Add config reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage.txt
+.idea/
 bin

--- a/env.go
+++ b/env.go
@@ -342,11 +342,11 @@ func newNoParserError(sf reflect.StructField) error {
 	return fmt.Errorf(`env: no parser found for field "%s" of type "%s"`, sf.Name, sf.Type)
 }
 
-// From is a convenience method that loads the content of reader into
+// ParseFrom is a convenience method that loads the content of reader into
 // environment variables. Useful for using a configuration file in one environment
 // and environment variable in another.
 // Each variable entry has the form VAR=value
-// Upon successful loading, From invokes Parse.
+// Upon successful loading, ParseFrom invokes Parse.
 // If no reader, invoke Parse.
 func ParseFrom(reader io.Reader, v interface{}) error {
 	if reader != nil {
@@ -358,7 +358,7 @@ func ParseFrom(reader io.Reader, v interface{}) error {
 			}
 			split := strings.SplitN(line, "=", 2)
 			if len(split) != 2 {
-				return fmt.Errorf(`env: parse error from reader "%s"`, line)
+				return fmt.Errorf(`env: parse error from reader "%s"`, strings.TrimSpace(line))
 			}
 			key := strings.TrimSpace(split[0])
 			value := strings.TrimSpace(split[1])

--- a/env.go
+++ b/env.go
@@ -362,7 +362,7 @@ func ParseFrom(reader io.Reader, v interface{}) error {
 			}
 			key := strings.TrimSpace(split[0])
 			value := strings.TrimSpace(split[1])
-			err := os.Setenv(key,  value)
+			err := os.Setenv(key, value)
 			if err != nil {
 				return err
 			}

--- a/env_test.go
+++ b/env_test.go
@@ -695,6 +695,30 @@ func TestParseInvalidURL(t *testing.T) {
 	assert.EqualError(t, env.Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable parse URL: parse nope://s s/: invalid character \" \" in host name")
 }
 
+func TestFrom(t *testing.T) {
+	record := `JPD_FOO=bar.now
+	ANOTHER=brick in the wall
+	WITH_SPACE=this is a long string
+	WITH_EQUALS=like@=Pass""
+	`
+	r := strings.NewReader(record)
+
+	type config struct {
+		Foo     string `env:"JPD_FOO"`
+		Another string `env:"ANOTHER"`
+		Space string `env:"WITH_SPACE"`
+		Equals string `env:"WITH_EQUALS"`
+	}
+
+	var cfg config
+	env.From(r, &cfg)
+
+	assert.Equal(t, "bar.now", cfg.Foo)
+	assert.Equal(t, "brick in the wall", cfg.Another)
+	assert.Equal(t, "this is a long string", cfg.Space)
+	assert.Equal(t, `like@=Pass""`, cfg.Equals)
+}
+
 func ExampleParse() {
 	type inner struct {
 		Foo string `env:"FOO" envDefault:"foobar"`

--- a/env_test.go
+++ b/env_test.go
@@ -711,12 +711,16 @@ func TestFrom(t *testing.T) {
 	}
 
 	var cfg config
-	env.From(r, &cfg)
+	env.ParseFrom(r, &cfg)
 
 	assert.Equal(t, "bar.now", cfg.Foo)
 	assert.Equal(t, "brick in the wall", cfg.Another)
 	assert.Equal(t, "this is a long string", cfg.Space)
 	assert.Equal(t, `like@=Pass""`, cfg.Equals)
+
+	// Reset the config.
+	cfg = config{}
+	env.ParseFrom(nil, &cfg)
 }
 
 func ExampleParse() {

--- a/env_test.go
+++ b/env_test.go
@@ -706,8 +706,8 @@ func TestFrom(t *testing.T) {
 	type config struct {
 		Foo     string `env:"JPD_FOO"`
 		Another string `env:"ANOTHER"`
-		Space string `env:"WITH_SPACE"`
-		Equals string `env:"WITH_EQUALS"`
+		Space   string `env:"WITH_SPACE"`
+		Equals  string `env:"WITH_EQUALS"`
 	}
 
 	var cfg config

--- a/env_test.go
+++ b/env_test.go
@@ -711,8 +711,9 @@ func TestFrom(t *testing.T) {
 	}
 
 	var cfg config
-	env.ParseFrom(r, &cfg)
+	err := env.ParseFrom(r, &cfg)
 
+	assert.NoError(t, err)
 	assert.Equal(t, "bar.now", cfg.Foo)
 	assert.Equal(t, "brick in the wall", cfg.Another)
 	assert.Equal(t, "this is a long string", cfg.Space)
@@ -721,6 +722,13 @@ func TestFrom(t *testing.T) {
 	// Reset the config.
 	cfg = config{}
 	env.ParseFrom(nil, &cfg)
+
+	// Should error with partial env setting
+	record = record + "Only"
+	r = strings.NewReader(record)
+	var cfg2 config
+	err = env.ParseFrom(r, &cfg2)
+	assert.EqualError(t, err, `env: parse error from reader "Only"`)
 }
 
 func ExampleParse() {


### PR DESCRIPTION
Adds a helper method to load a configuration as a reader. Useful for development where a file is easier than toggling an IDE's run settings, but where the developer doesn't want to have two paths for file and env vars.