### PR TITLE
fix: dont panic if cant set

### DIFF
--- a/env.go
+++ b/env.go
@@ -116,7 +116,10 @@ func doParse(ref reflect.Value, funcMap CustomParsers) error {
 
 	for i := 0; i < refType.NumField(); i++ {
 		refField := ref.Field(i)
-		if reflect.Ptr == refField.Kind() && !refField.IsNil() && refField.CanSet() {
+		if !refField.CanSet() {
+			continue
+		}
+		if reflect.Ptr == refField.Kind() && !refField.IsNil() {
 			err := Parse(refField.Interface())
 			if nil != err {
 				return err
@@ -262,7 +265,6 @@ func handleSlice(field reflect.Value, value string, sf reflect.StructField, func
 		}
 		result = reflect.Append(result, v)
 	}
-
 	field.Set(result)
 	return nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -727,3 +727,14 @@ func ExampleParseWithFuncs() {
 	fmt.Println(cfg.ExampleURL.String())
 	// Output: https://google.com
 }
+
+func TestUnexported(t *testing.T) {
+	type unexportedConfig struct {
+		home string `env:"HOME"`
+	}
+	cfg := unexportedConfig{}
+
+	os.Setenv("HOME", "/tmp/fakehome")
+	assert.NoError(t, env.Parse(&cfg))
+	assert.Empty(t, cfg.home)
+}

--- a/env_test.go
+++ b/env_test.go
@@ -728,13 +728,15 @@ func ExampleParseWithFuncs() {
 	// Output: https://google.com
 }
 
-func TestUnexported(t *testing.T) {
+func TestIgnoresUnexported(t *testing.T) {
 	type unexportedConfig struct {
-		home string `env:"HOME"`
+		home  string `env:"HOME"`
+		Home2 string `env:"HOME"`
 	}
 	cfg := unexportedConfig{}
 
 	os.Setenv("HOME", "/tmp/fakehome")
 	assert.NoError(t, env.Parse(&cfg))
 	assert.Empty(t, cfg.home)
+	assert.Equal(t, "/tmp/fakehome", cfg.Home2)
 }


### PR DESCRIPTION
will have the same behavior as JSON for example, which just ignores unexported fields. I think this was the behavior at some point and was broken by mistake.

closes #82