### PR TITLE
feat: support traversing non-defined type fields

### DIFF
--- a/env.go
+++ b/env.go
@@ -133,6 +133,13 @@ func doParse(ref reflect.Value, funcMap map[reflect.Type]ParserFunc) error {
 			}
 			continue
 		}
+		if reflect.Struct == refField.Kind() && refField.CanAddr() && refField.Type().Name() == "" {
+			err := Parse(refField.Addr().Interface())
+			if nil != err {
+				return err
+			}
+			continue
+		}
 		refTypeField := refType.Field(i)
 		value, err := get(refTypeField)
 		if err != nil {

--- a/env_test.go
+++ b/env_test.go
@@ -121,6 +121,10 @@ type Config struct {
 
 	CustomSeparator []string `env:"SEPSTRINGS" envSeparator:":"`
 
+	NonDefined struct {
+		String string `env:"NONDEFINED_STR"`
+	}
+
 	NotAnEnv   string
 	unexported string `env:"FOO"`
 }
@@ -245,6 +249,9 @@ func TestParsesEnv(t *testing.T) {
 
 	os.Setenv("SEPSTRINGS", strings.Join([]string{str1, str2}, ":"))
 
+	nonDefinedStr := "nonDefinedStr"
+	os.Setenv("NONDEFINED_STR", nonDefinedStr)
+
 	var cfg = Config{}
 	require.NoError(t, Parse(&cfg))
 
@@ -368,6 +375,7 @@ func TestParsesEnv(t *testing.T) {
 	assert.Equal(t, url2, cfg.URLPtrs[1].String())
 
 	assert.Equal(t, "postgres://localhost:5432/db", cfg.StringWithdefault)
+	assert.Equal(t, nonDefinedStr, cfg.NonDefined.String)
 
 	assert.Equal(t, str1, cfg.CustomSeparator[0])
 	assert.Equal(t, str2, cfg.CustomSeparator[1])


### PR DESCRIPTION
Adds support for traversing non-defined type fields

```golang
type T struct {
  NonDefinedField struct {
    Foo string `env:"T_FOO"`
  }
}
```

