### PR TITLE
test: run tests on Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - '1.11.x'
   - '1.12.x'
+  - '1.13.x'
 install: make setup
 script: make ci
 after_success:


### PR DESCRIPTION
test: Run tests on Go 1.13

This PR updates travis to run the test suite on Go 1.13 which is the current stable Go version