### PR TITLE
feat: Support to load values from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ import (
     "github.com/caarlos0/env"
 )
 type config struct {
-    Secret   string   `env:"SECRET,file"`
-    Password    string   `env:"PASSWORD,file" envDefault:"/tmp/password"`
+    Secret       string   `env:"SECRET,file"`
+    Password     string   `env:"PASSWORD,file" envDefault:"/tmp/password"`
     Certificate  string   `env:"CERTIFICATE,file" envDefault:"${CERTIFICATE_FILE}" envExpand:"true"`
 }
 func main() {

--- a/README.md
+++ b/README.md
@@ -131,6 +131,42 @@ type config struct {
 }
 ```
 
+
+## From file
+
+The `env` tag option `file` (e.g., `env:"tagKey,file"`) can be added
+to load the value from a file. The environment variable suffixed with `_FILE` is then expected and looked at for the path 
+to that file. If the suffixed version of the environment variable is not present, the value of the original environment 
+variable is used. 
+Example below
+
+```go
+package main
+import (
+    "fmt"
+    "time"
+    "github.com/caarlos0/env"
+)
+type config struct {
+    Password     string   `env:"PASSWORD,file"`
+    SecretKey    string   `env:"SECRET_KEY,file"`
+}
+func main() {
+	cfg := config{}
+	if err := env.Parse(&cfg); err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+
+	fmt.Printf("%+v\n", cfg)
+}
+```
+
+```sh
+$ PASSWORD=qwerty SECRET_KEY_FILE=/path/to/secret/key/file.pem \
+  go run main.go
+{Password:qwerty SecretKey:Content of the file.pem}
+```
+
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/caarlos0/env.svg)](https://starchart.cc/caarlos0/env)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ $ echo dvorak > /tmp/password
 $ echo coleman > /tmp/certificate
  
 $ SECRET=/tmp/secret  \
-  CERTIFICATE_FILE=/tmp/certificate
+  CERTIFICATE_FILE=/tmp/certificate \
   go run main.go
 {Secret:qwerty Password:dvorak Certificate:coleman}
 ```

--- a/README.md
+++ b/README.md
@@ -135,9 +135,8 @@ type config struct {
 ## From file
 
 The `env` tag option `file` (e.g., `env:"tagKey,file"`) can be added
-to load the value from a file. The environment variable suffixed with `_FILE` is then expected and looked at for the path 
-to that file. If the suffixed version of the environment variable is not present, the value of the original environment 
-variable is used. 
+to in order to indicate that the value of the variable shall be loaded from a file. The path of that file is given 
+by the environment variable associated with it
 Example below
 
 ```go
@@ -148,8 +147,9 @@ import (
     "github.com/caarlos0/env"
 )
 type config struct {
-    Password     string   `env:"PASSWORD,file"`
-    SecretKey    string   `env:"SECRET_KEY,file"`
+    Secret   string   `env:"SECRET,file"`
+    Password    string   `env:"PASSWORD,file" envDefault:"/tmp/password"`
+    Certificate  string   `env:"CERTIFICATE,file" envDefault:"${CERTIFICATE_FILE}" envExpand:"true"`
 }
 func main() {
 	cfg := config{}
@@ -162,9 +162,14 @@ func main() {
 ```
 
 ```sh
-$ PASSWORD=qwerty SECRET_KEY_FILE=/path/to/secret/key/file.pem \
+$ echo qwerty > /tmp/secret
+$ echo dvorak > /tmp/password
+$ echo coleman > /tmp/certificate
+ 
+$ SECRET=/tmp/secret  \
+  CERTIFICATE_FILE=/tmp/certificate
   go run main.go
-{Password:qwerty SecretKey:Content of the file.pem}
+{Secret:qwerty Password:dvorak Certificate:coleman}
 ```
 
 ## Stargazers over time

--- a/env.go
+++ b/env.go
@@ -197,7 +197,7 @@ func get(field reflect.StructField) (val string, err error) {
 		filename := val
 		val, err = getFromFile(filename)
 		if err != nil {
-			return "", fmt.Errorf(`env: could not load content of file "%s" from vaiable %s: %v`, filename, key, err)
+			return "", fmt.Errorf(`env: could not load content of file "%s" from variable %s: %v`, filename, key, err)
 		}
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -1114,7 +1114,7 @@ func TestFileNoParam(t *testing.T) {
 	err := Parse(&cfg)
 
 	assert.Error(t, err)
-	assert.EqualError(t, err, `env: could not load content of file "" from vaiable SECRET_KEY: open : no such file or directory`)
+	assert.EqualError(t, err, `env: could not load content of file "" from variable SECRET_KEY: open : no such file or directory`)
 }
 
 func TestFileWithDefault(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -1073,9 +1073,9 @@ func TestFile(t *testing.T) {
 	file2, err := ioutil.TempFile("", "sec_key_2_*")
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(file.Name(), []byte("the real secret1"), 660)
+	err = ioutil.WriteFile(file.Name(), []byte("the real secret1"), 0660)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(file2.Name(), []byte("the real secret2"), 660)
+	err = ioutil.WriteFile(file2.Name(), []byte("the real secret2"), 0660)
 	assert.NoError(t, err)
 
 	os.Setenv("HOST", "localhost")


### PR DESCRIPTION
We use github.com/caarlos0/env for config in our docker containers, as I expect many do. 
In this context it would be helpful be able to load configuration content from a files instead of environment variables in some cases.

Eg. instances where PEM files are needed and files are mounted into a docker container instead of added into the environment variables  

intended use would be 

```bash
env PRIVATE_RSA_KEY=key-to-be-overwritten \
    PRIVATE_RSA_KEY_FILE=/path/to/secret/rsa/key.pem
```
```go
type config struct {
	PrivRSAKey string `env:"PRIVATE_RSA_KEY,file"`
}
```

If `PRIVATE_RSA_KEY_FILE` is provided it will prefer the content in that file over the environment variable
