### PR TITLE
feat: Add "envUnset" variable tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ import (
 type config struct {
 	Home         string        `env:"HOME"`
 	Port         int           `env:"PORT" envDefault:"3000"`
+	Password     string        `env:"PASSWORD" envUnset:"true"`
 	IsProduction bool          `env:"PRODUCTION"`
 	Hosts        []string      `env:"HOSTS" envSeparator:":"`
 	Duration     time.Duration `env:"DURATION"`
@@ -90,6 +91,10 @@ this behavior by setting the `envSeparator` tag.
 If you set the `envExpand` tag, environment variables (either in `${var}` or
 `$var` format) in the string will be replaced according with the actual value
 of the variable.
+
+If you set the `envUnset` tag, the environment variables (either in `${var}` or 
+`$var` format) in the string will be unset from the environment. This is useful
+for passwords that you intend to read into memory and remove from the host.
 
 Unexported fields are ignored.
 

--- a/env.go
+++ b/env.go
@@ -166,6 +166,7 @@ func get(field reflect.StructField) (val string, err error) {
 	var exists bool
 	var loadFile bool
 	var expand = strings.EqualFold(field.Tag.Get("envExpand"), "true")
+	var unset = strings.EqualFold(field.Tag.Get("envUnset"), "true")
 
 	key, opts := parseKeyForOption(field.Tag.Get("env"))
 
@@ -187,6 +188,10 @@ func get(field reflect.StructField) (val string, err error) {
 
 	if expand {
 		val = os.ExpandEnv(val)
+	}
+
+	if unset {
+		defer os.Unsetenv(key)
 	}
 
 	if required && !exists {

--- a/env_test.go
+++ b/env_test.go
@@ -694,6 +694,40 @@ func TestParseExpandOption(t *testing.T) {
 	assert.Equal(t, "def1", cfg.Default)
 }
 
+func TestParseUnsetOption(t *testing.T) {
+	type config struct {
+		Host        string `env:"HOST" envDefault:"localhost"`
+		Port        int    `env:"PORT" envDefault:"3000" envExpand:"True"`
+		Password    string `env:"PASSWORD" envUnset:"True"`
+		SecretKey   string `env:"SECRET_KEY" envExpand:"True"`
+		ExpandKey   string `env:"EXPAND_KEY"`
+		CompoundKey string `env:"HOST_PORT" envDefault:"${HOST}:${PORT}" envExpand:"True"`
+		Default     string `env:"DEFAULT" envDefault:"def1"  envExpand:"True"`
+	}
+	defer os.Clearenv()
+
+	os.Setenv("HOST", "localhost")
+	os.Setenv("PORT", "3000")
+	os.Setenv("PASSWORD", "superSecret")
+	os.Setenv("EXPAND_KEY", "qwerty12345")
+	os.Setenv("SECRET_KEY", "${EXPAND_KEY}")
+
+	cfg := config{}
+	err := Parse(&cfg)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, 3000, cfg.Port)
+	assert.Equal(t, "superSecret", cfg.Password)
+	assert.Equal(t, "qwerty12345", cfg.SecretKey)
+	assert.Equal(t, "qwerty12345", cfg.ExpandKey)
+	assert.Equal(t, "localhost:3000", cfg.CompoundKey)
+	assert.Equal(t, "def1", cfg.Default)
+	unset, exists := os.LookupEnv("PASSWORD")
+	assert.Equal(t, "", unset)
+	assert.Equal(t, false, exists)
+}
+
 func TestCustomParser(t *testing.T) {
 	type foo struct {
 		name string


### PR DESCRIPTION
I find it useful to sometimes unset sensitive data after I have successfully read it out from the environment.

