### PR TITLE
fix: TestParseInvalidURL fails for golang:1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
   - '1.11.x'
   - '1.12.x'
   - '1.13.x'
+  - '1.14.x'
 install: make setup
 script: make ci
 after_success:

--- a/env_test.go
+++ b/env_test.go
@@ -981,7 +981,7 @@ func TestParseInvalidURL(t *testing.T) {
 	}
 	var cfg config
 	os.Setenv("EXAMPLE_URL_2", "nope://s s/")
-	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse nope://s s/: invalid character \" \" in host name")
+	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse \"nope://s s/\": invalid character \" \" in host name")
 }
 
 func ExampleParse() {

--- a/env_test.go
+++ b/env_test.go
@@ -986,7 +986,7 @@ func TestParseInvalidURL(t *testing.T) {
 
 	_, err := url.Parse(invalidURL)
 
-	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: " + err.Error())
+	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: "+err.Error())
 }
 
 func ExampleParse() {

--- a/env_test.go
+++ b/env_test.go
@@ -981,10 +981,10 @@ func TestParseInvalidURL(t *testing.T) {
 	}
 	var cfg config
 
-	var invalidUrl string = "nope://s s/"
-	os.Setenv("EXAMPLE_URL_2", invalidUrl)
+	invalidURL := "nope://s s/"
+	os.Setenv("EXAMPLE_URL_2", invalidURL)
 
-	_, err := url.Parse(invalidUrl)
+	_, err := url.Parse(invalidURL)
 
 	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: " + err.Error())
 }

--- a/env_test.go
+++ b/env_test.go
@@ -984,6 +984,7 @@ func TestParseInvalidURL(t *testing.T) {
 	invalidURL := "nope://s s/"
 	os.Setenv("EXAMPLE_URL_2", invalidURL)
 
+	//nolint
 	_, err := url.Parse(invalidURL)
 
 	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: "+err.Error())

--- a/env_test.go
+++ b/env_test.go
@@ -980,8 +980,13 @@ func TestParseInvalidURL(t *testing.T) {
 		ExampleURL url.URL `env:"EXAMPLE_URL_2"`
 	}
 	var cfg config
-	os.Setenv("EXAMPLE_URL_2", "nope://s s/")
-	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse \"nope://s s/\": invalid character \" \" in host name")
+
+	var invalidUrl string = "nope://s s/"
+	os.Setenv("EXAMPLE_URL_2", invalidUrl)
+
+	_, err := url.Parse(invalidUrl)
+
+	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: " + err.Error())
 }
 
 func ExampleParse() {


### PR DESCRIPTION
Unit tests fails with golang:1.14


How to reproduce:
```
docker run -it --rm -v ${PWD}:/app -w /app golang:1.14 make test
```
output:
```
...
=== RUN   TestParseInvalidURL
    TestParseInvalidURL: env_test.go:984:
                Error Trace:    env_test.go:984
                Error:          Error message not equal:
                                expected: "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse nope://s s/: invalid character \" \" in host name"
                                actual  : "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse \"nope://s s/\": invalid character \" \" in host name"
                Test:           TestParseInvalidURL
--- FAIL: TestParseInvalidURL (0.00s)
=== RUN   ExampleParse
--- PASS: ExampleParse (0.00s)
=== RUN   ExampleParseWithFuncs
--- PASS: ExampleParseWithFuncs (0.00s)
FAIL
coverage: 85.9% of statements in ./...
FAIL    github.com/taygius/env  0.073s
FAIL
make: *** [Makefile:16: test] Error 1
```