### PR TITLE
feat: Add decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,13 @@ $ SECRET=/tmp/secret  \
 ## With Decrypt
 
 The `env` tag option `decrypt` (e.g., `env:"tagKey,decrypt"`) can be added
-to in order to indicate that the value of the variable is encrypted and should be decrypted before set and parsed further.
-The value will be decrypted and then parsed accordingly so it supports all different types. If tag `file` is supplied the value will be loaded from the file and then decrypted and parsed accordingly.
+to in order to indicate that the value of the variable is encrypted and should be decrypted before set and parsed further. If tag `file` is set the value will be loaded from the file and then decrypted and set.
 
-Having the filename decrypted and then loaded is not supported. It will assume the filename is unecrypted but the content of the file shoule be unencrypted.
+Having the filename decrypted and then loaded is not supported. It will assume the filename is unencrypted but the content of the file should be decrypted.
 
-Other actions such as `expand` will happen **after** decryption is done.
+Other actions such as `expand` will happen **after** decryption is done if the `file` tag **is not set**. This is due to loading from file is the last action. So no other actions are possible after the file has been loaded.
 
-If the struct contains an `decrypt` tag it must be parsed with either `ParseWithDecrypt` or `ParseWithDecrypFuncs`. Otherwise an error will be returned.
+If the struct contains an `decrypt` tag it must be parsed with either `ParseWithDecrypt` or `ParseWithDecryptFuncs`. Otherwise an error will be returned.
 
 The second argument of these funcs should implement the `Decrypt` function of the `Decryptor` interface.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,54 @@ $ SECRET=/tmp/secret  \
 {Secret:qwerty Password:dvorak Certificate:coleman}
 ```
 
+
+## With Decrypt
+
+The `env` tag option `decrypt` (e.g., `env:"tagKey,decrypt"`) can be added
+to in order to indicate that the value of the variable is encrypted and should be decrypted before set and parsed further.
+The value will be decrypted and then parsed accordingly so it supports all different types. If tag `file` is supplied the value will be loaded from the file and then decrypted and parsed accordingly.
+
+Having the filename decrypted and then loaded is not supported. It will assume the filename is unecrypted but the content of the file shoule be unencrypted.
+
+Other actions such as `expand` will happen **after** decryption is done.
+
+If the struct contains an `decrypt` tag it must be parsed with either `ParseWithDecrypt` or `ParseWithDecrypFuncs`. Otherwise an error will be returned.
+
+The second argument of these funcs should implement the `Decrypt` function of the `Decryptor` interface.
+
+Example below
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/caarlos0/env"
+)
+
+type MyDecryptor struct {}
+
+// Decrypt will decrypt val using my decryption service.
+func (*MyDecryptor) Decrypt(val string) (string, error) {
+	decryptedVal := fmt.Sprintf("%s is now decrypted", val)
+	return decryptedVal, nil
+}
+
+type config struct {
+	Password     string   `env:"PASSWORD,decrypt"`
+}
+
+func main() {
+	cfg := config{}
+	if err := env.ParseWithDecrypt(&cfg);
+	err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+
+	fmt.Printf("%+v\n", cfg)
+}
+```
+
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/caarlos0/env.svg)](https://starchart.cc/caarlos0/env)

--- a/env.go
+++ b/env.go
@@ -102,15 +102,15 @@ func Parse(v interface{}) error {
 }
 
 // Decryptor is used to decrypt variables tagged with encrypted when using the
-// ParseWithEncryption function. It wraps Parse otherwise.
+// ParseWithDecrypt function. It wraps Parse otherwise.
 type Decryptor interface {
 	Decrypt(val string) (string, error)
 }
 
-// ParseWithEncryption is the same as `Parse` except it allows you to supply an decryptor
+// ParseWithDecrypt is the same as `Parse` except it allows you to supply an decryptor
 // to be used for decrypting any vars tagged with `encrypted`.
-func ParseWithEncryption(v interface{}, decryptor Decryptor) error {
-	return ParseWithEncryptionFuncs(v, map[reflect.Type]ParserFunc{}, decryptor)
+func ParseWithDecrypt(v interface{}, decryptor Decryptor) error {
+	return ParseWithDecryptFuncs(v, map[reflect.Type]ParserFunc{}, decryptor)
 }
 
 // ParseWithFuncs is the same as `Parse` except it also allows the user to pass
@@ -131,9 +131,9 @@ func ParseWithFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc) error {
 	return doParse(ref, parsers, nil)
 }
 
-// ParseWithEncryptionFuncs is the same as `ParseWithEncryption` except it also
+// ParseWithDecryptFuncs is the same as `ParseWithDecrypt` except it also
 // allows the user to pass in custom parsers.
-func ParseWithEncryptionFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, decryptor Decryptor) error {
+func ParseWithDecryptFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, decryptor Decryptor) error {
 	ptrRef := reflect.ValueOf(v)
 	if ptrRef.Kind() != reflect.Ptr {
 		return ErrNotAStructPtr
@@ -220,7 +220,7 @@ func get(field reflect.StructField, decryptor Decryptor) (val string, err error)
 
 	if encrypted {
 		if decryptor == nil {
-			return "", fmt.Errorf("env: detected encrypted var but called with Parse. Use ParseWithEncryption instead")
+			return "", fmt.Errorf("env: detected encrypted var but called with Parse. Use ParseWithDecrypt instead")
 		}
 		decryptedVal, err := decryptor.Decrypt(val)
 		if err != nil {

--- a/env.go
+++ b/env.go
@@ -148,9 +148,6 @@ func ParseWithDecryptFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, d
 	if err != nil {
 		return err
 	}
-	if decryptor == nil {
-		return fmt.Errorf("env: decryptor must be set")
-	}
 	return doParse(ref, parsers, decryptor)
 }
 
@@ -163,14 +160,14 @@ func doParse(ref reflect.Value, funcMap map[reflect.Type]ParserFunc, decryptor D
 			continue
 		}
 		if reflect.Ptr == refField.Kind() && !refField.IsNil() {
-			err := ParseWithFuncs(refField.Interface(), funcMap)
+			err := ParseWithDecryptFuncs(refField.Interface(), funcMap, decryptor)
 			if err != nil {
 				return err
 			}
 			continue
 		}
 		if reflect.Struct == refField.Kind() && refField.CanAddr() && refField.Type().Name() == "" {
-			err := Parse(refField.Addr().Interface())
+			err := ParseWithDecrypt(refField.Addr().Interface(), decryptor)
 			if err != nil {
 				return err
 			}

--- a/env.go
+++ b/env.go
@@ -148,6 +148,9 @@ func ParseWithDecryptFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, d
 	if err != nil {
 		return err
 	}
+	if decryptor == nil {
+		return fmt.Errorf("env: decryptor must be set")
+	}
 	return doParse(ref, parsers, decryptor)
 }
 

--- a/env_test.go
+++ b/env_test.go
@@ -1299,15 +1299,3 @@ func TestFileWithDefault(t *testing.T) {
 	assert.Equal(t, "secret", cfg.SecretKey)
 
 }
-
-// func TestFileNoParamRequired(t *testing.T) {
-// 	type config struct {
-// 		SecretKey string `env:"SECRET_KEY,file,required"`
-// 	}
-// 	defer os.Clearenv()
-// 	cfg := config{}
-// 	err := Parse(&cfg)
-
-// 	assert.Error(t, err)
-// 	assert.EqualError(t, err, "env: required environment variable \"SECRET_KEY\" is not set")
-// }

--- a/env_test.go
+++ b/env_test.go
@@ -413,15 +413,6 @@ func TestParsesEnvWithDecrypt(t *testing.T) {
 	assert.Equal(t, encrypted, cfg.StringWithEncryption)
 }
 
-func TestParsesEnvWithDecryptNilDecryptor(t *testing.T) {
-	defer os.Clearenv()
-	var encrypted = "encrypted"
-	os.Setenv("ENCRYPTED_STRING", encrypted)
-
-	var cfg = ConfigWithEncryption{}
-	assert.EqualError(t, ParseWithDecrypt(&cfg, nil), "env: decryptor must be set")
-}
-
 func TestParsesEnvWithDecryptFile(t *testing.T) {
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file,decrypt"`

--- a/env_test.go
+++ b/env_test.go
@@ -1091,6 +1091,20 @@ func TestParseInvalidURL(t *testing.T) {
 	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse \"nope://s s/\": invalid character \" \" in host name")
 }
 
+func TestFailingOnInne(t *testing.T) {
+	type inner struct {
+		Encrypted string `env:"ENCRYPTED,decrypt"`
+	}
+	type config struct {
+		Home  string `env:"HOME,required"`
+		Inner inner
+	}
+	os.Setenv("HOME", "/tmp/fakehome")
+	os.Setenv("ENCRYPTED", "encrypted")
+	var cfg config
+	assert.EqualError(t, Parse(&cfg), "env: detected decrypt tag on var but called with Parse. Use ParseWithDecrypt instead")
+}
+
 func ExampleParse() {
 	type inner struct {
 		Foo string `env:"FOO" envDefault:"foobar"`
@@ -1285,3 +1299,15 @@ func TestFileWithDefault(t *testing.T) {
 	assert.Equal(t, "secret", cfg.SecretKey)
 
 }
+
+// func TestFileNoParamRequired(t *testing.T) {
+// 	type config struct {
+// 		SecretKey string `env:"SECRET_KEY,file,required"`
+// 	}
+// 	defer os.Clearenv()
+// 	cfg := config{}
+// 	err := Parse(&cfg)
+
+// 	assert.Error(t, err)
+// 	assert.EqualError(t, err, "env: required environment variable \"SECRET_KEY\" is not set")
+// }

--- a/env_test.go
+++ b/env_test.go
@@ -413,6 +413,15 @@ func TestParsesEnvWithDecrypt(t *testing.T) {
 	assert.Equal(t, encrypted, cfg.StringWithEncryption)
 }
 
+func TestParsesEnvWithDecryptNilDecryptor(t *testing.T) {
+	defer os.Clearenv()
+	var encrypted = "encrypted"
+	os.Setenv("ENCRYPTED_STRING", encrypted)
+
+	var cfg = ConfigWithEncryption{}
+	assert.EqualError(t, ParseWithDecrypt(&cfg, nil), "env: decryptor must be set")
+}
+
 func TestParsesEnvWithDecryptFile(t *testing.T) {
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file,decrypt"`
@@ -816,8 +825,10 @@ func TestParseWithFuncsNoPtr(t *testing.T) {
 
 func TestParseWithFuncsInvalidType(t *testing.T) {
 	var c int
-	err := ParseWithFuncs(&c, nil)
-	assert.EqualError(t, err, "env: expected a pointer to a Struct")
+	err1 := ParseWithFuncs(&c, nil)
+	err2 := ParseWithDecryptFuncs(&c, nil, &TestDecryptor{})
+	assert.EqualError(t, err1, "env: expected a pointer to a Struct")
+	assert.EqualError(t, err2, "env: expected a pointer to a Struct")
 }
 
 func TestCustomParserError(t *testing.T) {


### PR DESCRIPTION
### Add decrypt option

Adds support for decrypting values directly using any struct implementing the `Decryptor` interface.
If `ParseWithDecrypt` or `ParseWithDecryptFuncs` is called and tag `decrypt` is present it will be decrypted and set.

If envs are parsed and has the tag `decrypt` but called with `Parse` or `ParseWithFuncs` it will return an error. This is to preserve the old API with any changes / need for passing the `Decryptor`.

So decryption is possible with something like:

```go
package main

import (
	"fmt"
	"github.com/caarlos0/env"
)

type MyDecryptor struct {}

// Decrypt will decrypt val using my decryption service.
func (*MyDecryptor) Decrypt(val string) (string, error) {
	decryptedVal := fmt.Sprintf("%s is now decrypted", val)
	return decryptedVal, nil
}

type config struct {
	Password string `env:"PASSWORD,decrypt"`
}

func main() {
	decryptor := MyDecryptor{}
	cfg := config{}
	if err := env.ParseWithDecrypt(&cfg, &decryptor); err != nil {
		fmt.Printf("%+v\n", err)
	}

	fmt.Printf("%+v\n", cfg)
}
```