### PR TITLE
feat: Add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ type Config struct {
 	Password string `env:"PASSWORD"`
 }
 
-
 func main() {
 	cfg := &Config{}
 	opts := &env.Options{Environment: map[string]string{
@@ -280,7 +279,41 @@ func main() {
 	}}
 
 	// Load env vars.
-	if err := env.Parse(&cfg.envData, opts); err != nil {
+	if err := env.Parse(cfg, opts); err != nil {
+		log.Fatal(err)
+	}
+
+	// Print the loaded data.
+	fmt.Printf("%+v\n", cfg.envData)
+}
+```
+
+### Changing default tag name
+
+You can change what tag name to use for setting the env vars by setting the `Options.TagName`
+variable.
+
+For example
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/caarlos0/env"
+)
+
+type Config struct {
+	Password string `json:"PASSWORD"`
+}
+
+func main() {
+	cfg := &Config{}
+	opts := &env.Options{TagName: "json"}
+
+	// Load env vars.
+	if err := env.Parse(cfg, opts); err != nil {
 		log.Fatal(err)
 	}
 

--- a/README.md
+++ b/README.md
@@ -179,14 +179,13 @@ $ SECRET=/tmp/secret  \
 ## With Decrypt
 
 The `env` tag option `decrypt` (e.g., `env:"tagKey,decrypt"`) can be added
-to in order to indicate that the value of the variable is encrypted and should be decrypted before set and parsed further.
-The value will be decrypted and then parsed accordingly so it supports all different types. If tag `file` is supplied the value will be loaded from the file and then decrypted and parsed accordingly.
+to in order to indicate that the value of the variable is encrypted and should be decrypted before set and parsed further. If tag `file` is set the value will be loaded from the file and then decrypted and set.
 
-Having the filename decrypted and then loaded is not supported. It will assume the filename is unecrypted but the content of the file shoule be unencrypted.
+Having the filename decrypted and then loaded is not supported. It will assume the filename is unencrypted but the content of the file should be decrypted.
 
-Other actions such as `expand` will happen **after** decryption is done.
+Other actions such as `expand` will happen **after** decryption is done if the `file` tag **is not set**. This is due to loading from file is the last action. So no other actions are possible after the file has been loaded.
 
-If the struct contains an `decrypt` tag it must be parsed with either `ParseWithDecrypt` or `ParseWithDecrypFuncs`. Otherwise an error will be returned.
+If the struct contains an `decrypt` tag it must be parsed with either `ParseWithDecrypt` or `ParseWithDecryptFuncs`. Otherwise an error will be returned.
 
 The second argument of these funcs should implement the `Decrypt` function of the `Decryptor` interface.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,54 @@ $ SECRET=/tmp/secret  \
 {Secret:qwerty Password:dvorak Certificate:coleman}
 ```
 
+
+## With Decrypt
+
+The `env` tag option `decrypt` (e.g., `env:"tagKey,decrypt"`) can be added
+to in order to indicate that the value of the variable is encrypted and should be decrypted before set and parsed further.
+The value will be decrypted and then parsed accordingly so it supports all different types. If tag `file` is supplied the value will be loaded from the file and then decrypted and parsed accordingly.
+
+Having the filename decrypted and then loaded is not supported. It will assume the filename is unecrypted but the content of the file shoule be unencrypted.
+
+Other actions such as `expand` will happen **after** decryption is done.
+
+If the struct contains an `decrypt` tag it must be parsed with either `ParseWithDecrypt` or `ParseWithDecrypFuncs`. Otherwise an error will be returned.
+
+The second argument of these funcs should implement the `Decrypt` function of the `Decryptor` interface.
+
+Example below
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/caarlos0/env"
+)
+
+type MyDecryptor struct {}
+
+// Decrypt will decrypt val using my decryption service.
+func (*MyDecryptor) Decrypt(val string) (string, error) {
+	decryptedVal := fmt.Sprintf("%s is now decrypted", val)
+	return decryptedVal, nil
+}
+
+type config struct {
+	Password     string   `env:"PASSWORD,decrypt"`
+}
+
+func main() {
+	cfg := config{}
+	if err := env.ParseWithDecrypt(&cfg);
+	err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+
+	fmt.Printf("%+v\n", cfg)
+}
+```
+
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/caarlos0/env.svg)](https://starchart.cc/caarlos0/env)

--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ func main() {
 
 ### Environment
 
-By setting the `Options.Environment` map you can till `Parse` to set those `keys` and `values`
-as env vars before parsing is done.
+By setting the `Options.Environment` map you can tell `Parse` to add those `keys` and `values`
+as env vars before parsing is done. These envs are stored in the map and never actually set by `os.Setenv`.
 
 This can make your testing scenarios a bit more clean and easy to handle.
 

--- a/env.go
+++ b/env.go
@@ -102,15 +102,15 @@ func Parse(v interface{}) error {
 }
 
 // Decryptor is used to decrypt variables tagged with encrypted when using the
-// ParseWithEncryption function. It wraps Parse otherwise.
+// ParseWithDecrypt function. It wraps Parse otherwise.
 type Decryptor interface {
 	Decrypt(val string) (string, error)
 }
 
-// ParseWithEncryption is the same as `Parse` except it allows you to supply an decryptor
+// ParseWithDecrypt is the same as `Parse` except it allows you to supply an decryptor
 // to be used for decrypting any vars tagged with `encrypted`.
-func ParseWithEncryption(v interface{}, decryptor Decryptor) error {
-	return ParseWithEncryptionFuncs(v, map[reflect.Type]ParserFunc{}, decryptor)
+func ParseWithDecrypt(v interface{}, decryptor Decryptor) error {
+	return ParseWithDecryptFuncs(v, map[reflect.Type]ParserFunc{}, decryptor)
 }
 
 // ParseWithFuncs is the same as `Parse` except it also allows the user to pass
@@ -131,9 +131,9 @@ func ParseWithFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc) error {
 	return doParse(ref, parsers, nil)
 }
 
-// ParseWithEncryptionFuncs is the same as `ParseWithEncryption` except it also
+// ParseWithDecryptFuncs is the same as `ParseWithDecrypt` except it also
 // allows the user to pass in custom parsers.
-func ParseWithEncryptionFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, decryptor Decryptor) error {
+func ParseWithDecryptFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, decryptor Decryptor) error {
 	ptrRef := reflect.ValueOf(v)
 	if ptrRef.Kind() != reflect.Ptr {
 		return ErrNotAStructPtr
@@ -220,7 +220,7 @@ func get(field reflect.StructField, decryptor Decryptor) (val string, err error)
 
 	if encrypted {
 		if decryptor == nil {
-			return "", fmt.Errorf("env: detected encrypted var but called with Parse. Use ParseWithEncryption instead")
+			return "", fmt.Errorf("env: detected encrypted var but called with Parse. Use ParseWithDecrypt instead")
 		}
 		decryptedVal, err := decryptor.Decrypt(val)
 		if err != nil {

--- a/env.go
+++ b/env.go
@@ -148,6 +148,9 @@ func ParseWithDecryptFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, d
 	if err != nil {
 		return err
 	}
+	if decryptor == nil {
+		return fmt.Errorf("env: decryptor must be set")
+	}
 	return doParse(ref, parsers, decryptor)
 }
 

--- a/env.go
+++ b/env.go
@@ -101,6 +101,20 @@ type Options struct {
 	Decryptor Decryptor
 	// Environment keys and values that will be accessible for the service.
 	Environment map[string]string
+	// TagName specifies another tagname to use rather than the default env.
+	TagName string
+}
+
+// configure will do the basic configurations and defaults.
+func configure(opts *Options) *Options {
+	if opts == nil {
+		opts = &Options{}
+	}
+	if opts.TagName == "" {
+		opts.TagName = "env"
+	}
+
+	return opts
 }
 
 // Decryptor is used to decrypt variables tagged with encrypted when using the
@@ -118,9 +132,7 @@ func Parse(v interface{}, opts *Options) error {
 // ParseWithFuncs is the same as `Parse` except it also allows the user to pass
 // in custom parsers.
 func ParseWithFuncs(v interface{}, funcMap map[reflect.Type]ParserFunc, opts *Options) error {
-	if opts == nil {
-		opts = &Options{}
-	}
+	opts = configure(opts)
 
 	ptrRef := reflect.ValueOf(v)
 	if ptrRef.Kind() != reflect.Ptr {
@@ -187,7 +199,7 @@ func get(field reflect.StructField, opts *Options) (val string, err error) {
 	var decrypt bool
 	var expand = strings.EqualFold(field.Tag.Get("envExpand"), "true")
 
-	key, tags := parseKeyForOption(field.Tag.Get("env"))
+	key, tags := parseKeyForOption(field.Tag.Get(opts.TagName))
 
 	for _, tag := range tags {
 		switch tag {

--- a/env_test.go
+++ b/env_test.go
@@ -1299,15 +1299,3 @@ func TestFileWithDefault(t *testing.T) {
 	assert.Equal(t, "secret", cfg.SecretKey)
 
 }
-
-// func TestFileNoParamRequired(t *testing.T) {
-// 	type config struct {
-// 		SecretKey string `env:"SECRET_KEY,file,required"`
-// 	}
-// 	defer os.Clearenv()
-// 	cfg := config{}
-// 	err := Parse(&cfg)
-
-// 	assert.Error(t, err)
-// 	assert.EqualError(t, err, "env: required environment variable \"SECRET_KEY\" is not set")
-// }

--- a/env_test.go
+++ b/env_test.go
@@ -789,7 +789,9 @@ func TestErrorRequiredNotSetWithDefault(t *testing.T) {
 	}
 
 	cfg := &config{}
-	assert.EqualError(t, Parse(cfg), "env: required environment variable \"IS_REQUIRED\" is not set")
+
+	assert.NoError(t, Parse(cfg))
+	assert.Equal(t, "important", cfg.IsRequired)
 }
 
 func TestParseExpandOption(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -435,15 +435,6 @@ func TestSetEnvError(t *testing.T) {
 	assert.EqualError(t, Parse(&cfg, &Options{Environment: envs}), `env: couldn't set env with key "=" and value "VALUE1"`)
 }
 
-// func TestParsesEnvWithDecryptNilDecryptor(t *testing.T) {
-// 	defer os.Clearenv()
-// 	var encrypted = "encrypted"
-// 	os.Setenv("ENCRYPTED_STRING", encrypted)
-
-// 	var cfg = ConfigWithEncryption{}
-// 	assert.EqualError(t, Parse(&cfg, nil), "env: decryptor must be set")
-// }
-
 func TestParsesEnvWithDecryptFile(t *testing.T) {
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file,decrypt"`
@@ -468,7 +459,7 @@ func TestParsesEnvWithDecryptFile(t *testing.T) {
 	assert.Equal(t, "secret", cfg.SecretKey)
 }
 
-func TestParsesFileWithDecrypt(t *testing.T) {
+func TestParsesFileWithDecryptError(t *testing.T) {
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file,decrypt"`
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -1091,6 +1091,20 @@ func TestParseInvalidURL(t *testing.T) {
 	assert.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse \"nope://s s/\": invalid character \" \" in host name")
 }
 
+func TestFailingOnInne(t *testing.T) {
+	type inner struct {
+		Encrypted string `env:"ENCRYPTED,decrypt"`
+	}
+	type config struct {
+		Home  string `env:"HOME,required"`
+		Inner inner
+	}
+	os.Setenv("HOME", "/tmp/fakehome")
+	os.Setenv("ENCRYPTED", "encrypted")
+	var cfg config
+	assert.EqualError(t, Parse(&cfg), "env: detected decrypt tag on var but called with Parse. Use ParseWithDecrypt instead")
+}
+
 func ExampleParse() {
 	type inner struct {
 		Foo string `env:"FOO" envDefault:"foobar"`
@@ -1285,3 +1299,15 @@ func TestFileWithDefault(t *testing.T) {
 	assert.Equal(t, "secret", cfg.SecretKey)
 
 }
+
+// func TestFileNoParamRequired(t *testing.T) {
+// 	type config struct {
+// 		SecretKey string `env:"SECRET_KEY,file,required"`
+// 	}
+// 	defer os.Clearenv()
+// 	cfg := config{}
+// 	err := Parse(&cfg)
+
+// 	assert.Error(t, err)
+// 	assert.EqualError(t, err, "env: required environment variable \"SECRET_KEY\" is not set")
+// }

--- a/env_test.go
+++ b/env_test.go
@@ -429,15 +429,21 @@ func TestSetEnv(t *testing.T) {
 	assert.Equal(t, 3, cfg.Key2)
 }
 
-// func TestSetEnvError(t *testing.T) {
-// 	defer os.Clearenv()
-// 	envs := map[string]string{
-// 		"=": "VALUE1",
-// 	}
+func TestJSONTag(t *testing.T) {
+	defer os.Clearenv()
+	type config struct {
+		Key1 string `json:"KEY1"`
+		Key2 int    `json:"KEY2,required"`
+	}
 
-// 	cfg := Config{}
-// 	assert.EqualError(t, Parse(&cfg, &Options{Environment: envs}), `env: couldn't set env with key "=" and value "VALUE1"`)
-// }
+	os.Setenv("KEY1", "VALUE7")
+	os.Setenv("KEY2", "5")
+
+	cfg := config{}
+	require.NoError(t, Parse(&cfg, &Options{TagName: "json"}))
+	assert.Equal(t, "VALUE7", cfg.Key1)
+	assert.Equal(t, 5, cfg.Key2)
+}
 
 func TestParsesEnvWithDecryptFile(t *testing.T) {
 	type config struct {

--- a/env_test.go
+++ b/env_test.go
@@ -433,7 +433,7 @@ func TestJSONTag(t *testing.T) {
 	defer os.Clearenv()
 	type config struct {
 		Key1 string `json:"KEY1"`
-		Key2 int    `json:"KEY2,required"`
+		Key2 int    `json:"KEY2"`
 	}
 
 	os.Setenv("KEY1", "VALUE7")

--- a/env_test.go
+++ b/env_test.go
@@ -414,26 +414,30 @@ func TestParsesEnvWithDecrypt(t *testing.T) {
 
 func TestSetEnv(t *testing.T) {
 	defer os.Clearenv()
+	type config struct {
+		Key1 string `env:"KEY1,required"`
+		Key2 int    `env:"KEY2,required"`
+	}
 	envs := map[string]string{
 		"KEY1": "VALUE1",
-		"KEY2": "VALUE2",
+		"KEY2": "3",
 	}
 
-	cfg := Config{}
+	cfg := config{}
 	require.NoError(t, Parse(&cfg, &Options{Environment: envs}))
-	assert.Equal(t, envs["KEY1"], os.Getenv("KEY1"))
-	assert.Equal(t, envs["KEY2"], os.Getenv("KEY2"))
+	assert.Equal(t, "VALUE1", cfg.Key1)
+	assert.Equal(t, 3, cfg.Key2)
 }
 
-func TestSetEnvError(t *testing.T) {
-	defer os.Clearenv()
-	envs := map[string]string{
-		"=": "VALUE1",
-	}
+// func TestSetEnvError(t *testing.T) {
+// 	defer os.Clearenv()
+// 	envs := map[string]string{
+// 		"=": "VALUE1",
+// 	}
 
-	cfg := Config{}
-	assert.EqualError(t, Parse(&cfg, &Options{Environment: envs}), `env: couldn't set env with key "=" and value "VALUE1"`)
-}
+// 	cfg := Config{}
+// 	assert.EqualError(t, Parse(&cfg, &Options{Environment: envs}), `env: couldn't set env with key "=" and value "VALUE1"`)
+// }
 
 func TestParsesEnvWithDecryptFile(t *testing.T) {
 	type config struct {

--- a/env_test.go
+++ b/env_test.go
@@ -413,6 +413,15 @@ func TestParsesEnvWithDecrypt(t *testing.T) {
 	assert.Equal(t, encrypted, cfg.StringWithEncryption)
 }
 
+func TestParsesEnvWithDecryptNilDecryptor(t *testing.T) {
+	defer os.Clearenv()
+	var encrypted = "encrypted"
+	os.Setenv("ENCRYPTED_STRING", encrypted)
+
+	var cfg = ConfigWithEncryption{}
+	assert.EqualError(t, ParseWithDecrypt(&cfg, nil), "env: decryptor must be set")
+}
+
 func TestParsesEnvWithDecryptFile(t *testing.T) {
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file,decrypt"`
@@ -816,8 +825,10 @@ func TestParseWithFuncsNoPtr(t *testing.T) {
 
 func TestParseWithFuncsInvalidType(t *testing.T) {
 	var c int
-	err := ParseWithFuncs(&c, nil)
-	assert.EqualError(t, err, "env: expected a pointer to a Struct")
+	err1 := ParseWithFuncs(&c, nil)
+	err2 := ParseWithDecryptFuncs(&c, nil, &TestDecryptor{})
+	assert.EqualError(t, err1, "env: expected a pointer to a Struct")
+	assert.EqualError(t, err2, "env: expected a pointer to a Struct")
 }
 
 func TestCustomParserError(t *testing.T) {


### PR DESCRIPTION
## Add Options

Added optional Options to the `Parse` and `ParseWithFuncs` functions. It's not mandatory so to not break the API with previous versions.

Also fixed evaluation bug when having `required` tag and `envDefault` set as per #115 

### Decryption
Ref #127 
Adds support for decrypting values directly using any struct implementing the `Decryptor` interface.

Just set the `Decryptor` in `Options` and pass it into `Parse` or `ParseWithFuncs` functions.

```go
package main

import (
	"context"
	"encoding/base64"
	"fmt"
	"log"

	"github.com/aws/aws-sdk-go-v2/aws/external"
	"github.com/aws/aws-sdk-go-v2/service/kms"
	"github.com/caarlos0/env"
)

type Config struct {
	kms     *kms.Client
	envData struct {
		Password string `env:"PASSWORD,decrypt"`
	}
}

// Decrypt will decrypt val using KMS.
func (c *Config) Decrypt(val string) (string, error) {
	raw, err := base64.StdEncoding.DecodeString(val)
	if err != nil {
		return "", fmt.Errorf("couldn't base64 decode string")
	}

	resp, err := c.kms.DecryptRequest(&kms.DecryptInput{
		CiphertextBlob: raw,
	}).Send(context.Background())
	if err != nil {
		return "", fmt.Errorf("couldn't decrypt string. %s", err.Error())
	}

	return string(resp.DecryptOutput.Plaintext), nil
}

func main() {
	// Load the default AWS config and create KMS service.
	awsCfg, err := external.LoadDefaultAWSConfig()
	if err != nil {
		log.Fatal(err)
	}
	cfg := &Config{kms: kms.New(awsCfg)}
	opts := &env.Options{Decryptor: cfg}

	// Load env vars.
	if err := env.Parse(&cfg.envData, opts); err != nil {
		log.Fatal(err)
	}

	// Print the loaded data.
	fmt.Printf("%+v\n", cfg.envData)
}
```

### Passing "Environment" variables
Ref #111 
Adds support for adding a map of environment variables that will be accessible for the `Parse` and `ParseWithFuncs` functions.

```go
package main

import (
	"fmt"
	"log"

	"github.com/caarlos0/env"
)

type Config struct {
	Password string `env:"PASSWORD"`
}

func main() {
	cfg := &Config{}
	opts := &env.Options{Environment: map[string]string{
		"PASSWORD": "MY_PASSWORD",
	}}

	// Load env vars.
	if err := env.Parse(cfg, opts); err != nil {
		log.Fatal(err)
	}

	// Print the loaded data.
	fmt.Printf("%+v\n", cfg.envData)
}
```

Simply add a `map[string]string` to `Options.Environment` and pass it to `Parse` or `ParseWithFuncs` as options.

### Changing default Tag from env
Ref #112 
Adds support from changing the default tag when parsing an struct from `env` to something else, for example `json`.

Simply set the tag name you want to use under `Options.TagName` and pass the options to `Parse` or `ParseWithFuncs`.

```go
package main

import (
	"fmt"
	"log"

	"github.com/caarlos0/env"
)

type Config struct {
	Password string `json:"PASSWORD"`
}

func main() {
	cfg := &Config{}
	opts := &env.Options{TagName: "json"}

	// Load env vars.
	if err := env.Parse(cfg, opts); err != nil {
		log.Fatal(err)
	}

	// Print the loaded data.
	fmt.Printf("%+v\n", cfg.envData)
}
```
