### PR TITLE
fix: support custom slice types

### DIFF
--- a/env.go
+++ b/env.go
@@ -224,10 +224,6 @@ func getOr(key, defaultValue string) (value string, exists bool) {
 }
 
 func set(field reflect.Value, sf reflect.StructField, value string, funcMap map[reflect.Type]ParserFunc) error {
-	if field.Kind() == reflect.Slice {
-		return handleSlice(field, value, sf, funcMap)
-	}
-
 	var tm = asTextUnmarshaler(field)
 	if tm != nil {
 		var err = tm.UnmarshalText([]byte(value))
@@ -261,6 +257,10 @@ func set(field reflect.Value, sf reflect.StructField, value string, funcMap map[
 
 		fieldee.Set(reflect.ValueOf(val).Convert(typee))
 		return nil
+	}
+
+	if field.Kind() == reflect.Slice {
+		return handleSlice(field, value, sf, funcMap)
 	}
 
 	return newNoParserError(sf)

--- a/env_test.go
+++ b/env_test.go
@@ -1178,3 +1178,22 @@ func TestFileWithDefault(t *testing.T) {
 	assert.Equal(t, "secret", cfg.SecretKey)
 
 }
+
+func TestCustomSliceType(t *testing.T) {
+	type customslice []byte
+
+	type config struct {
+		SecretKey customslice `env:"SECRET_KEY"`
+	}
+
+	parsecustomsclice := func(value string) (interface{}, error) {
+		return customslice(value), nil
+	}
+
+	defer os.Clearenv()
+	os.Setenv("SECRET_KEY", "somesecretkey")
+
+	var cfg config
+	err := ParseWithFuncs(&cfg, map[reflect.Type]ParserFunc{reflect.TypeOf(customslice{}): parsecustomsclice})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Custom slice types never reach their `ParseFunc` because they get treated as "normal" slice types, the issue was mentioned here: https://github.com/caarlos0/env/issues/110

An easy fix is to move handling slices to after custom parse functions, do you think there are any downsides to that?  