### PR TITLE
return error when required env set with empty value

### DIFF
--- a/env.go
+++ b/env.go
@@ -225,7 +225,6 @@ func doParse(ref reflect.Value, funcMap map[reflect.Type]ParserFunc, opts []Opti
 
 func get(field reflect.StructField, opts []Options) (val string, err error) {
 	var required bool
-	var exists bool
 	var loadFile bool
 	var expand = strings.EqualFold(field.Tag.Get("envExpand"), "true")
 
@@ -245,13 +244,13 @@ func get(field reflect.StructField, opts []Options) (val string, err error) {
 	}
 
 	defaultValue, defExists := field.Tag.Lookup("envDefault")
-	val, exists = getOr(key, defaultValue, defExists, getEnvironment(opts))
+	val, _ = getOr(key, defaultValue, defExists, getEnvironment(opts))
 
 	if expand {
 		val = os.ExpandEnv(val)
 	}
 
-	if required && !exists {
+	if required && len(val) == 0 {
 		return "", fmt.Errorf(`env: required environment variable %q is not set`, key)
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -662,10 +662,22 @@ func TestNoErrorRequiredSet(t *testing.T) {
 
 	cfg := &config{}
 
-	os.Setenv("IS_REQUIRED", "")
+	os.Setenv("IS_REQUIRED", "true")
 	defer os.Clearenv()
 	assert.NoError(t, Parse(cfg))
-	assert.Equal(t, "", cfg.IsRequired)
+	assert.Equal(t, "true", cfg.IsRequired)
+}
+
+func TestErrorRequiredSetWithEmptyValue(t *testing.T) {
+	type config struct {
+		IsRequired string `env:"IS_REQUIRED,required"`
+	}
+
+	cfg := &config{}
+
+	os.Setenv("IS_REQUIRED", "")
+	defer os.Clearenv()
+	assert.EqualError(t, Parse(cfg), "env: required environment variable \"IS_REQUIRED\" is not set")
 }
 
 func TestErrorRequiredWithDefault(t *testing.T) {
@@ -677,8 +689,7 @@ func TestErrorRequiredWithDefault(t *testing.T) {
 
 	os.Setenv("IS_REQUIRED", "")
 	defer os.Clearenv()
-	assert.NoError(t, Parse(cfg))
-	assert.Equal(t, "", cfg.IsRequired)
+	assert.EqualError(t, Parse(cfg), "env: required environment variable \"IS_REQUIRED\" is not set")
 }
 
 func TestErrorRequiredNotSet(t *testing.T) {


### PR DESCRIPTION
Fix #133 

@caarlos0 PTAL, the PR ignore exist since it checks the lens of Val, 
`TestErrorRequiredWithDefault` i think we should also inform the end-user that the required env set with an empty value even when a default assigned this why the test changed.