### PR TITLE
Update godoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/github/workflow/status/caarlos0/env/build?style=for-the-badge)](https://github.com/caarlos0/env/actions?workflow=build)
 [![Coverage Status](https://img.shields.io/codecov/c/gh/caarlos0/env.svg?logo=codecov&style=for-the-badge)](https://codecov.io/gh/caarlos0/env)
-[![](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge)](http://godoc.org/github.com/caarlos0/env)
+[![](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge)](http://godoc.org/github.com/caarlos0/env/v6)
 
 Simple lib to parse envs to structs in Go.
 


### PR DESCRIPTION
Godoc badge from README points to http://godoc.org/github.com/caarlos0/env, which redirects to https://pkg.go.dev/github.com/caarlos0/env and contains information about an old version of this package.

This MR fixes this by appending v6 suffix to godoc link.