### PR TITLE
Add check for blank env key

### DIFF
--- a/env.go
+++ b/env.go
@@ -248,9 +248,8 @@ func get(field reflect.StructField, opts []Options) (val string, err error) {
 	if key == "" {
 		if defExists {
 			return defaultValue, nil
-		} else {
-			return "", nil
 		}
+		return "", nil
 	}
 
 	val, exists = getOr(key, defaultValue, defExists, getEnvironment(opts))

--- a/env.go
+++ b/env.go
@@ -245,6 +245,14 @@ func get(field reflect.StructField, opts []Options) (val string, err error) {
 	}
 
 	defaultValue, defExists := field.Tag.Lookup("envDefault")
+	if key == "" {
+		if defExists {
+			return defaultValue, nil
+		} else {
+			return "", nil
+		}
+	}
+
 	val, exists = getOr(key, defaultValue, defExists, getEnvironment(opts))
 
 	if expand {

--- a/env_test.go
+++ b/env_test.go
@@ -1232,3 +1232,21 @@ func TestCustomSliceType(t *testing.T) {
 	err := ParseWithFuncs(&cfg, map[reflect.Type]ParserFunc{reflect.TypeOf(customslice{}): parsecustomsclice})
 	assert.NoError(t, err)
 }
+
+func TestBlankKey (t *testing.T) {
+	type testStruct struct {
+		Blank string
+		BlankWithTag string `env:""`
+	}
+
+	val := testStruct{}
+
+	defer os.Clearenv()
+	os.Setenv("", "You should not see this")
+
+	err := Parse(&val)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", val.Blank)
+	assert.Equal(t, "", val.BlankWithTag)
+}


### PR DESCRIPTION
This adds a check (and corresponding test) to prevent rogue blank env keys in the environment from producing unexpected results on fields without `env` tags, as per #152 .