### PR TITLE
feat: go 1.16, test on mac and windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,12 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  goreleaser:
+    strategy:
+      matrix:
+        go-version: [ ~1.16 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       -
         name: Checkout
@@ -21,36 +25,31 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: ${{ matrix.go-version }}
       -
         name: Cache Go modules
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       -
-        name: Make Setup
-        run: |
-          make setup
-      -
-        name: Make CI
-        run: |
-          make ci
+        name: CI
+        run: make setup ci
       -
         name: Upload coverage
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v1
+        if: matrix.os == 'ubuntu-latest'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
-        if: success() && startsWith(github.ref, 'refs/tags/')
+        if: success() && startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
         with:
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ~1.16
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          skip-go-installation: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-go:
-  enabled: true

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ TEST_PATTERN?=.
 export GO111MODULE := on
 
 setup:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
-	go mod download
+	go mod tidy
 .PHONY: setup
 
 build:
@@ -28,7 +27,7 @@ lint:
 	./bin/golangci-lint run ./...
 .PHONY: lint
 
-ci: build test lint
+ci: build test
 .PHONY: ci
 
 card:

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/caarlos0/env/v6
 
 require github.com/stretchr/testify v1.7.0
 
-go 1.14
+go 1.16


### PR DESCRIPTION
- upgrade to go 1.16
- test on linux, mac and windows
- golangci-lint action