### PR TITLE
fix: blank env keys populating fields with undesirable values

### DIFF
--- a/env.go
+++ b/env.go
@@ -282,7 +282,7 @@ func getOr(key, defaultValue string, defExists bool, envs map[string]string) (va
 	switch {
 	case (!exists || key == "") && defExists:
 		return defaultValue, true
-	case !exists:
+	case !exists || key == "":
 		return "", false
 	}
 


### PR DESCRIPTION
Same issue as seen in caarlos0#152 with fields that don't specify an env key being populated by a blank key in the host environment.

This was resolved in 2ed4d36 but seems to have been re-introduced in e244b8a. Adding an additional case to the value check seems to solve it.