### PR TITLE
test: replace testify with is

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,3 +9,5 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+release:
+  discussion_category_name: General

--- a/env_test.go
+++ b/env_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/matryer/is"
 )
 
 type unmarshaler struct {
@@ -151,6 +151,8 @@ type NestedStruct struct {
 }
 
 func TestParsesEnv(t *testing.T) {
+	is := is.New(t)
+
 	defer os.Clearenv()
 
 	tos := func(v interface{}) string {
@@ -256,139 +258,141 @@ func TestParsesEnv(t *testing.T) {
 	os.Setenv("NONDEFINED_STR", nonDefinedStr)
 
 	cfg := Config{}
-	require.NoError(t, Parse(&cfg))
+	is.NoErr(Parse(&cfg))
 
-	require.Equal(t, str1, cfg.String)
-	require.Equal(t, &str1, cfg.StringPtr)
-	require.Equal(t, str1, cfg.Strings[0])
-	require.Equal(t, str2, cfg.Strings[1])
-	require.Equal(t, &str1, cfg.StringPtrs[0])
-	require.Equal(t, &str2, cfg.StringPtrs[1])
+	is.Equal(str1, cfg.String)
+	is.Equal(&str1, cfg.StringPtr)
+	is.Equal(str1, cfg.Strings[0])
+	is.Equal(str2, cfg.Strings[1])
+	is.Equal(&str1, cfg.StringPtrs[0])
+	is.Equal(&str2, cfg.StringPtrs[1])
 
-	require.Equal(t, bool1, cfg.Bool)
-	require.Equal(t, &bool1, cfg.BoolPtr)
-	require.Equal(t, bool1, cfg.Bools[0])
-	require.Equal(t, bool2, cfg.Bools[1])
-	require.Equal(t, &bool1, cfg.BoolPtrs[0])
-	require.Equal(t, &bool2, cfg.BoolPtrs[1])
+	is.Equal(bool1, cfg.Bool)
+	is.Equal(&bool1, cfg.BoolPtr)
+	is.Equal(bool1, cfg.Bools[0])
+	is.Equal(bool2, cfg.Bools[1])
+	is.Equal(&bool1, cfg.BoolPtrs[0])
+	is.Equal(&bool2, cfg.BoolPtrs[1])
 
-	require.Equal(t, int1, cfg.Int)
-	require.Equal(t, &int1, cfg.IntPtr)
-	require.Equal(t, int1, cfg.Ints[0])
-	require.Equal(t, int2, cfg.Ints[1])
-	require.Equal(t, &int1, cfg.IntPtrs[0])
-	require.Equal(t, &int2, cfg.IntPtrs[1])
+	is.Equal(int1, cfg.Int)
+	is.Equal(&int1, cfg.IntPtr)
+	is.Equal(int1, cfg.Ints[0])
+	is.Equal(int2, cfg.Ints[1])
+	is.Equal(&int1, cfg.IntPtrs[0])
+	is.Equal(&int2, cfg.IntPtrs[1])
 
-	require.Equal(t, int81, cfg.Int8)
-	require.Equal(t, &int81, cfg.Int8Ptr)
-	require.Equal(t, int81, cfg.Int8s[0])
-	require.Equal(t, int82, cfg.Int8s[1])
-	require.Equal(t, &int81, cfg.Int8Ptrs[0])
-	require.Equal(t, &int82, cfg.Int8Ptrs[1])
+	is.Equal(int81, cfg.Int8)
+	is.Equal(&int81, cfg.Int8Ptr)
+	is.Equal(int81, cfg.Int8s[0])
+	is.Equal(int82, cfg.Int8s[1])
+	is.Equal(&int81, cfg.Int8Ptrs[0])
+	is.Equal(&int82, cfg.Int8Ptrs[1])
 
-	require.Equal(t, int161, cfg.Int16)
-	require.Equal(t, &int161, cfg.Int16Ptr)
-	require.Equal(t, int161, cfg.Int16s[0])
-	require.Equal(t, int162, cfg.Int16s[1])
-	require.Equal(t, &int161, cfg.Int16Ptrs[0])
-	require.Equal(t, &int162, cfg.Int16Ptrs[1])
+	is.Equal(int161, cfg.Int16)
+	is.Equal(&int161, cfg.Int16Ptr)
+	is.Equal(int161, cfg.Int16s[0])
+	is.Equal(int162, cfg.Int16s[1])
+	is.Equal(&int161, cfg.Int16Ptrs[0])
+	is.Equal(&int162, cfg.Int16Ptrs[1])
 
-	require.Equal(t, int321, cfg.Int32)
-	require.Equal(t, &int321, cfg.Int32Ptr)
-	require.Equal(t, int321, cfg.Int32s[0])
-	require.Equal(t, int322, cfg.Int32s[1])
-	require.Equal(t, &int321, cfg.Int32Ptrs[0])
-	require.Equal(t, &int322, cfg.Int32Ptrs[1])
+	is.Equal(int321, cfg.Int32)
+	is.Equal(&int321, cfg.Int32Ptr)
+	is.Equal(int321, cfg.Int32s[0])
+	is.Equal(int322, cfg.Int32s[1])
+	is.Equal(&int321, cfg.Int32Ptrs[0])
+	is.Equal(&int322, cfg.Int32Ptrs[1])
 
-	require.Equal(t, int641, cfg.Int64)
-	require.Equal(t, &int641, cfg.Int64Ptr)
-	require.Equal(t, int641, cfg.Int64s[0])
-	require.Equal(t, int642, cfg.Int64s[1])
-	require.Equal(t, &int641, cfg.Int64Ptrs[0])
-	require.Equal(t, &int642, cfg.Int64Ptrs[1])
+	is.Equal(int641, cfg.Int64)
+	is.Equal(&int641, cfg.Int64Ptr)
+	is.Equal(int641, cfg.Int64s[0])
+	is.Equal(int642, cfg.Int64s[1])
+	is.Equal(&int641, cfg.Int64Ptrs[0])
+	is.Equal(&int642, cfg.Int64Ptrs[1])
 
-	require.Equal(t, uint1, cfg.Uint)
-	require.Equal(t, &uint1, cfg.UintPtr)
-	require.Equal(t, uint1, cfg.Uints[0])
-	require.Equal(t, uint2, cfg.Uints[1])
-	require.Equal(t, &uint1, cfg.UintPtrs[0])
-	require.Equal(t, &uint2, cfg.UintPtrs[1])
+	is.Equal(uint1, cfg.Uint)
+	is.Equal(&uint1, cfg.UintPtr)
+	is.Equal(uint1, cfg.Uints[0])
+	is.Equal(uint2, cfg.Uints[1])
+	is.Equal(&uint1, cfg.UintPtrs[0])
+	is.Equal(&uint2, cfg.UintPtrs[1])
 
-	require.Equal(t, uint81, cfg.Uint8)
-	require.Equal(t, &uint81, cfg.Uint8Ptr)
-	require.Equal(t, uint81, cfg.Uint8s[0])
-	require.Equal(t, uint82, cfg.Uint8s[1])
-	require.Equal(t, &uint81, cfg.Uint8Ptrs[0])
-	require.Equal(t, &uint82, cfg.Uint8Ptrs[1])
+	is.Equal(uint81, cfg.Uint8)
+	is.Equal(&uint81, cfg.Uint8Ptr)
+	is.Equal(uint81, cfg.Uint8s[0])
+	is.Equal(uint82, cfg.Uint8s[1])
+	is.Equal(&uint81, cfg.Uint8Ptrs[0])
+	is.Equal(&uint82, cfg.Uint8Ptrs[1])
 
-	require.Equal(t, uint161, cfg.Uint16)
-	require.Equal(t, &uint161, cfg.Uint16Ptr)
-	require.Equal(t, uint161, cfg.Uint16s[0])
-	require.Equal(t, uint162, cfg.Uint16s[1])
-	require.Equal(t, &uint161, cfg.Uint16Ptrs[0])
-	require.Equal(t, &uint162, cfg.Uint16Ptrs[1])
+	is.Equal(uint161, cfg.Uint16)
+	is.Equal(&uint161, cfg.Uint16Ptr)
+	is.Equal(uint161, cfg.Uint16s[0])
+	is.Equal(uint162, cfg.Uint16s[1])
+	is.Equal(&uint161, cfg.Uint16Ptrs[0])
+	is.Equal(&uint162, cfg.Uint16Ptrs[1])
 
-	require.Equal(t, uint321, cfg.Uint32)
-	require.Equal(t, &uint321, cfg.Uint32Ptr)
-	require.Equal(t, uint321, cfg.Uint32s[0])
-	require.Equal(t, uint322, cfg.Uint32s[1])
-	require.Equal(t, &uint321, cfg.Uint32Ptrs[0])
-	require.Equal(t, &uint322, cfg.Uint32Ptrs[1])
+	is.Equal(uint321, cfg.Uint32)
+	is.Equal(&uint321, cfg.Uint32Ptr)
+	is.Equal(uint321, cfg.Uint32s[0])
+	is.Equal(uint322, cfg.Uint32s[1])
+	is.Equal(&uint321, cfg.Uint32Ptrs[0])
+	is.Equal(&uint322, cfg.Uint32Ptrs[1])
 
-	require.Equal(t, uint641, cfg.Uint64)
-	require.Equal(t, &uint641, cfg.Uint64Ptr)
-	require.Equal(t, uint641, cfg.Uint64s[0])
-	require.Equal(t, uint642, cfg.Uint64s[1])
-	require.Equal(t, &uint641, cfg.Uint64Ptrs[0])
-	require.Equal(t, &uint642, cfg.Uint64Ptrs[1])
+	is.Equal(uint641, cfg.Uint64)
+	is.Equal(&uint641, cfg.Uint64Ptr)
+	is.Equal(uint641, cfg.Uint64s[0])
+	is.Equal(uint642, cfg.Uint64s[1])
+	is.Equal(&uint641, cfg.Uint64Ptrs[0])
+	is.Equal(&uint642, cfg.Uint64Ptrs[1])
 
-	require.Equal(t, float321, cfg.Float32)
-	require.Equal(t, &float321, cfg.Float32Ptr)
-	require.Equal(t, float321, cfg.Float32s[0])
-	require.Equal(t, float322, cfg.Float32s[1])
-	require.Equal(t, &float321, cfg.Float32Ptrs[0])
-	require.Equal(t, &float322, cfg.Float32Ptrs[1])
+	is.Equal(float321, cfg.Float32)
+	is.Equal(&float321, cfg.Float32Ptr)
+	is.Equal(float321, cfg.Float32s[0])
+	is.Equal(float322, cfg.Float32s[1])
+	is.Equal(&float321, cfg.Float32Ptrs[0])
+	is.Equal(&float322, cfg.Float32Ptrs[1])
 
-	require.Equal(t, float641, cfg.Float64)
-	require.Equal(t, &float641, cfg.Float64Ptr)
-	require.Equal(t, float641, cfg.Float64s[0])
-	require.Equal(t, float642, cfg.Float64s[1])
-	require.Equal(t, &float641, cfg.Float64Ptrs[0])
-	require.Equal(t, &float642, cfg.Float64Ptrs[1])
+	is.Equal(float641, cfg.Float64)
+	is.Equal(&float641, cfg.Float64Ptr)
+	is.Equal(float641, cfg.Float64s[0])
+	is.Equal(float642, cfg.Float64s[1])
+	is.Equal(&float641, cfg.Float64Ptrs[0])
+	is.Equal(&float642, cfg.Float64Ptrs[1])
 
-	require.Equal(t, duration1, cfg.Duration)
-	require.Equal(t, &duration1, cfg.DurationPtr)
-	require.Equal(t, duration1, cfg.Durations[0])
-	require.Equal(t, duration2, cfg.Durations[1])
-	require.Equal(t, &duration1, cfg.DurationPtrs[0])
-	require.Equal(t, &duration2, cfg.DurationPtrs[1])
+	is.Equal(duration1, cfg.Duration)
+	is.Equal(&duration1, cfg.DurationPtr)
+	is.Equal(duration1, cfg.Durations[0])
+	is.Equal(duration2, cfg.Durations[1])
+	is.Equal(&duration1, cfg.DurationPtrs[0])
+	is.Equal(&duration2, cfg.DurationPtrs[1])
 
-	require.Equal(t, unmarshaler1, cfg.Unmarshaler)
-	require.Equal(t, &unmarshaler1, cfg.UnmarshalerPtr)
-	require.Equal(t, unmarshaler1, cfg.Unmarshalers[0])
-	require.Equal(t, unmarshaler2, cfg.Unmarshalers[1])
-	require.Equal(t, &unmarshaler1, cfg.UnmarshalerPtrs[0])
-	require.Equal(t, &unmarshaler2, cfg.UnmarshalerPtrs[1])
+	is.Equal(unmarshaler1, cfg.Unmarshaler)
+	is.Equal(&unmarshaler1, cfg.UnmarshalerPtr)
+	is.Equal(unmarshaler1, cfg.Unmarshalers[0])
+	is.Equal(unmarshaler2, cfg.Unmarshalers[1])
+	is.Equal(&unmarshaler1, cfg.UnmarshalerPtrs[0])
+	is.Equal(&unmarshaler2, cfg.UnmarshalerPtrs[1])
 
-	require.Equal(t, url1, cfg.URL.String())
-	require.Equal(t, url1, cfg.URLPtr.String())
-	require.Equal(t, url1, cfg.URLs[0].String())
-	require.Equal(t, url2, cfg.URLs[1].String())
-	require.Equal(t, url1, cfg.URLPtrs[0].String())
-	require.Equal(t, url2, cfg.URLPtrs[1].String())
+	is.Equal(url1, cfg.URL.String())
+	is.Equal(url1, cfg.URLPtr.String())
+	is.Equal(url1, cfg.URLs[0].String())
+	is.Equal(url2, cfg.URLs[1].String())
+	is.Equal(url1, cfg.URLPtrs[0].String())
+	is.Equal(url2, cfg.URLPtrs[1].String())
 
-	require.Equal(t, "postgres://localhost:5432/db", cfg.StringWithdefault)
-	require.Equal(t, nonDefinedStr, cfg.NonDefined.String)
+	is.Equal("postgres://localhost:5432/db", cfg.StringWithdefault)
+	is.Equal(nonDefinedStr, cfg.NonDefined.String)
 
-	require.Equal(t, str1, cfg.CustomSeparator[0])
-	require.Equal(t, str2, cfg.CustomSeparator[1])
+	is.Equal(str1, cfg.CustomSeparator[0])
+	is.Equal(str2, cfg.CustomSeparator[1])
 
-	require.Empty(t, cfg.NotAnEnv)
+	is.Equal(cfg.NotAnEnv, "")
 
-	require.Empty(t, cfg.unexported)
+	is.Equal(cfg.unexported, "")
 }
 
 func TestSetEnvAndTagOptsChain(t *testing.T) {
+	is := is.New(t)
+
 	defer os.Clearenv()
 	type config struct {
 		Key1 string `mytag:"KEY1,required"`
@@ -400,12 +404,14 @@ func TestSetEnvAndTagOptsChain(t *testing.T) {
 	}
 
 	cfg := config{}
-	require.NoError(t, Parse(&cfg, Options{TagName: "mytag"}, Options{Environment: envs}))
-	require.Equal(t, "VALUE1", cfg.Key1)
-	require.Equal(t, 3, cfg.Key2)
+	is.NoErr(Parse(&cfg, Options{TagName: "mytag"}, Options{Environment: envs}))
+	is.Equal("VALUE1", cfg.Key1)
+	is.Equal(3, cfg.Key2)
 }
 
 func TestJSONTag(t *testing.T) {
+	is := is.New(t)
+
 	defer os.Clearenv()
 	type config struct {
 		Key1 string `json:"KEY1"`
@@ -416,12 +422,14 @@ func TestJSONTag(t *testing.T) {
 	os.Setenv("KEY2", "5")
 
 	cfg := config{}
-	require.NoError(t, Parse(&cfg, Options{TagName: "json"}))
-	require.Equal(t, "VALUE7", cfg.Key1)
-	require.Equal(t, 5, cfg.Key2)
+	is.NoErr(Parse(&cfg, Options{TagName: "json"}))
+	is.Equal("VALUE7", cfg.Key1)
+	is.Equal(5, cfg.Key2)
 }
 
 func TestParsesEnvInner(t *testing.T) {
+	is := is.New(t)
+
 	os.Setenv("innervar", "someinnervalue")
 	os.Setenv("innernum", "8")
 	defer os.Clearenv()
@@ -429,9 +437,9 @@ func TestParsesEnvInner(t *testing.T) {
 		InnerStruct: &InnerStruct{},
 		unexported:  &InnerStruct{},
 	}
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, "someinnervalue", cfg.InnerStruct.Inner)
-	require.Equal(t, uint(8), cfg.InnerStruct.Number)
+	is.NoErr(Parse(&cfg))
+	is.Equal("someinnervalue", cfg.InnerStruct.Inner)
+	is.Equal(uint(8), cfg.InnerStruct.Number)
 }
 
 func TestParsesEnvInnerFails(t *testing.T) {
@@ -442,15 +450,16 @@ func TestParsesEnvInnerFails(t *testing.T) {
 		}
 	}
 	os.Setenv("NUMBER", "not-a-number")
-	cfg := config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Number\" of type \"int\": strconv.ParseInt: parsing \"not-a-number\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "Number" of type "int": strconv.ParseInt: parsing "not-a-number": invalid syntax`)
 }
 
 func TestParsesEnvInnerNil(t *testing.T) {
+	is := is.New(t)
+
 	os.Setenv("innervar", "someinnervalue")
 	defer os.Clearenv()
 	cfg := ParentStruct{}
-	require.NoError(t, Parse(&cfg))
+	is.NoErr(Parse(&cfg))
 }
 
 func TestParsesEnvInnerInvalid(t *testing.T) {
@@ -459,169 +468,153 @@ func TestParsesEnvInnerInvalid(t *testing.T) {
 	cfg := ParentStruct{
 		InnerStruct: &InnerStruct{},
 	}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Number\" of type \"uint\": strconv.ParseUint: parsing \"-547\": invalid syntax")
+	isErrorWithMessage(t, Parse(&cfg), `env: parse error on field "Number" of type "uint": strconv.ParseUint: parsing "-547": invalid syntax`)
 }
 
 func TestParsesEnvNested(t *testing.T) {
+	is := is.New(t)
+
 	os.Setenv("nestedvar", "somenestedvalue")
 	defer os.Clearenv()
 	var cfg ForNestedStruct
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, "somenestedvalue", cfg.NestedVar)
+	is.NoErr(Parse(&cfg))
+	is.Equal("somenestedvalue", cfg.NestedVar)
 }
 
 func TestEmptyVars(t *testing.T) {
+	is := is.New(t)
+
 	os.Clearenv()
 	cfg := Config{}
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, "", cfg.String)
-	require.Equal(t, false, cfg.Bool)
-	require.Equal(t, 0, cfg.Int)
-	require.Equal(t, uint(0), cfg.Uint)
-	require.Equal(t, uint64(0), cfg.Uint64)
-	require.Equal(t, int64(0), cfg.Int64)
-	require.Equal(t, 0, len(cfg.Strings))
-	require.Equal(t, 0, len(cfg.CustomSeparator))
-	require.Equal(t, 0, len(cfg.Ints))
-	require.Equal(t, 0, len(cfg.Bools))
+	is.NoErr(Parse(&cfg))
+	is.Equal("", cfg.String)
+	is.Equal(false, cfg.Bool)
+	is.Equal(0, cfg.Int)
+	is.Equal(uint(0), cfg.Uint)
+	is.Equal(uint64(0), cfg.Uint64)
+	is.Equal(int64(0), cfg.Int64)
+	is.Equal(0, len(cfg.Strings))
+	is.Equal(0, len(cfg.CustomSeparator))
+	is.Equal(0, len(cfg.Ints))
+	is.Equal(0, len(cfg.Bools))
 }
 
 func TestPassAnInvalidPtr(t *testing.T) {
 	var thisShouldBreak int
-	require.EqualError(t, Parse(&thisShouldBreak), "env: expected a pointer to a Struct")
+	isErrorWithMessage(t, Parse(&thisShouldBreak), "env: expected a pointer to a Struct")
 }
 
 func TestPassReference(t *testing.T) {
 	cfg := Config{}
-	require.EqualError(t, Parse(cfg), "env: expected a pointer to a Struct")
+	isErrorWithMessage(t, Parse(cfg), "env: expected a pointer to a Struct")
 }
 
 func TestInvalidBool(t *testing.T) {
 	os.Setenv("BOOL", "should-be-a-bool")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Bool\" of type \"bool\": strconv.ParseBool: parsing \"should-be-a-bool\": invalid syntax")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Bool" of type "bool": strconv.ParseBool: parsing "should-be-a-bool": invalid syntax`)
 }
 
 func TestInvalidInt(t *testing.T) {
 	os.Setenv("INT", "should-be-an-int")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Int\" of type \"int\": strconv.ParseInt: parsing \"should-be-an-int\": invalid syntax")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Int" of type "int": strconv.ParseInt: parsing "should-be-an-int": invalid syntax`)
 }
 
 func TestInvalidUint(t *testing.T) {
 	os.Setenv("UINT", "-44")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Uint\" of type \"uint\": strconv.ParseUint: parsing \"-44\": invalid syntax")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Uint" of type "uint": strconv.ParseUint: parsing "-44": invalid syntax`)
 }
 
 func TestInvalidFloat32(t *testing.T) {
 	os.Setenv("FLOAT32", "AAA")
 	defer os.Clearenv()
 
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Float32\" of type \"float32\": strconv.ParseFloat: parsing \"AAA\": invalid syntax")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Float32" of type "float32": strconv.ParseFloat: parsing "AAA": invalid syntax`)
 }
 
 func TestInvalidFloat64(t *testing.T) {
 	os.Setenv("FLOAT64", "AAA")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Float64\" of type \"float64\": strconv.ParseFloat: parsing \"AAA\": invalid syntax")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Float64" of type "float64": strconv.ParseFloat: parsing "AAA": invalid syntax`)
 }
 
 func TestInvalidUint64(t *testing.T) {
 	os.Setenv("UINT64", "AAA")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Uint64\" of type \"uint64\": strconv.ParseUint: parsing \"AAA\": invalid syntax")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Uint64" of type "uint64": strconv.ParseUint: parsing "AAA": invalid syntax`)
 }
 
 func TestInvalidInt64(t *testing.T) {
 	os.Setenv("INT64", "AAA")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Int64\" of type \"int64\": strconv.ParseInt: parsing \"AAA\": invalid syntax")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Int64" of type "int64": strconv.ParseInt: parsing "AAA": invalid syntax`)
 }
 
 func TestInvalidInt64Slice(t *testing.T) {
+	os.Setenv("BADINTS", "A,2,3")
+	defer os.Clearenv()
 	type config struct {
 		BadFloats []int64 `env:"BADINTS"`
 	}
-
-	os.Setenv("BADINTS", "A,2,3")
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"BadFloats\" of type \"[]int64\": strconv.ParseInt: parsing \"A\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "BadFloats" of type "[]int64": strconv.ParseInt: parsing "A": invalid syntax`)
 }
 
 func TestInvalidUInt64Slice(t *testing.T) {
+	os.Setenv("BADINTS", "A,2,3")
+	defer os.Clearenv()
 	type config struct {
 		BadFloats []uint64 `env:"BADINTS"`
 	}
-
-	os.Setenv("BADFLOATS", "A,2,3")
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"BadFloats\" of type \"[]uint64\": strconv.ParseUint: parsing \"A\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "BadFloats" of type "[]uint64": strconv.ParseUint: parsing "A": invalid syntax`)
 }
 
 func TestInvalidFloat32Slice(t *testing.T) {
+	os.Setenv("BADFLOATS", "A,2.0,3.0")
+	defer os.Clearenv()
 	type config struct {
 		BadFloats []float32 `env:"BADFLOATS"`
 	}
-
-	os.Setenv("BADFLOATS", "A,2.0,3.0")
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"BadFloats\" of type \"[]float32\": strconv.ParseFloat: parsing \"A\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "BadFloats" of type "[]float32": strconv.ParseFloat: parsing "A": invalid syntax`)
 }
 
 func TestInvalidFloat64Slice(t *testing.T) {
+	os.Setenv("BADFLOATS", "A,2.0,3.0")
+	defer os.Clearenv()
 	type config struct {
 		BadFloats []float64 `env:"BADFLOATS"`
 	}
-
-	os.Setenv("BADFLOATS", "A,2.0,3.0")
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"BadFloats\" of type \"[]float64\": strconv.ParseFloat: parsing \"A\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "BadFloats" of type "[]float64": strconv.ParseFloat: parsing "A": invalid syntax`)
 }
 
 func TestInvalidBoolsSlice(t *testing.T) {
+	os.Setenv("BADBOOLS", "t,f,TRUE,faaaalse")
+	defer os.Clearenv()
 	type config struct {
 		BadBools []bool `env:"BADBOOLS"`
 	}
-
-	os.Setenv("BADBOOLS", "t,f,TRUE,faaaalse")
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"BadBools\" of type \"[]bool\": strconv.ParseBool: parsing \"faaaalse\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "BadBools" of type "[]bool": strconv.ParseBool: parsing "faaaalse": invalid syntax`)
 }
 
 func TestInvalidDuration(t *testing.T) {
 	os.Setenv("DURATION", "should-be-a-valid-duration")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Duration\" of type \"time.Duration\": unable to parse duration: time: invalid duration \"should-be-a-valid-duration\"")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Duration" of type "time.Duration": unable to parse duration: time: invalid duration "should-be-a-valid-duration"`)
 }
 
 func TestInvalidDurations(t *testing.T) {
 	os.Setenv("DURATIONS", "1s,contains-an-invalid-duration,3s")
 	defer os.Clearenv()
-
-	cfg := Config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"Durations\" of type \"[]time.Duration\": unable to parse duration: time: invalid duration \"contains-an-invalid-duration\"")
+	isErrorWithMessage(t, Parse(&Config{}), `env: parse error on field "Durations" of type "[]time.Duration": unable to parse duration: time: invalid duration "contains-an-invalid-duration"`)
 }
 
 func TestParseStructWithoutEnvTag(t *testing.T) {
+	is := is.New(t)
+
 	cfg := Config{}
-	require.NoError(t, Parse(&cfg))
-	require.Empty(t, cfg.NotAnEnv)
+	is.NoErr(Parse(&cfg))
+	is.Equal(cfg.NotAnEnv, "")
 }
 
 func TestParseStructWithInvalidFieldKind(t *testing.T) {
@@ -629,8 +622,7 @@ func TestParseStructWithInvalidFieldKind(t *testing.T) {
 		WontWorkByte byte `env:"BLAH"`
 	}
 	os.Setenv("BLAH", "a")
-	cfg := config{}
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"WontWorkByte\" of type \"uint8\": strconv.ParseUint: parsing \"a\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "WontWorkByte" of type "uint8": strconv.ParseUint: parsing "a": invalid syntax`)
 }
 
 func TestUnsupportedSliceType(t *testing.T) {
@@ -641,8 +633,7 @@ func TestUnsupportedSliceType(t *testing.T) {
 	os.Setenv("WONTWORK", "1,2,3")
 	defer os.Clearenv()
 
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: no parser found for field \"WontWork\" of type \"[]map[int]int\"")
+	isErrorWithMessage(t, Parse(&config{}), `env: no parser found for field "WontWork" of type "[]map[int]int"`)
 }
 
 func TestBadSeparator(t *testing.T) {
@@ -650,14 +641,15 @@ func TestBadSeparator(t *testing.T) {
 		WontWork []int `env:"WONTWORK" envSeparator:":"`
 	}
 
-	cfg := &config{}
 	os.Setenv("WONTWORK", "1,2,3,4")
 	defer os.Clearenv()
 
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"WontWork\" of type \"[]int\": strconv.ParseInt: parsing \"1,2,3,4\": invalid syntax")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "WontWork" of type "[]int": strconv.ParseInt: parsing "1,2,3,4": invalid syntax`)
 }
 
 func TestNoErrorRequiredSet(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		IsRequired string `env:"IS_REQUIRED,required"`
 	}
@@ -666,11 +658,13 @@ func TestNoErrorRequiredSet(t *testing.T) {
 
 	os.Setenv("IS_REQUIRED", "")
 	defer os.Clearenv()
-	require.NoError(t, Parse(cfg))
-	require.Equal(t, "", cfg.IsRequired)
+	is.NoErr(Parse(cfg))
+	is.Equal("", cfg.IsRequired)
 }
 
 func TestErrorRequiredWithDefault(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		IsRequired string `env:"IS_REQUIRED,required" envDefault:"important"`
 	}
@@ -679,31 +673,33 @@ func TestErrorRequiredWithDefault(t *testing.T) {
 
 	os.Setenv("IS_REQUIRED", "")
 	defer os.Clearenv()
-	require.NoError(t, Parse(cfg))
-	require.Equal(t, "", cfg.IsRequired)
+	is.NoErr(Parse(cfg))
+	is.Equal("", cfg.IsRequired)
 }
 
 func TestErrorRequiredNotSet(t *testing.T) {
 	type config struct {
 		IsRequired string `env:"IS_REQUIRED,required"`
 	}
-
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: required environment variable \"IS_REQUIRED\" is not set")
+	isErrorWithMessage(t, Parse(&config{}), `env: required environment variable "IS_REQUIRED" is not set`)
 }
 
 func TestErrorRequiredNotSetWithDefault(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		IsRequired string `env:"IS_REQUIRED,required" envDefault:"important"`
 	}
 
 	cfg := &config{}
 
-	require.NoError(t, Parse(cfg))
-	require.Equal(t, "important", cfg.IsRequired)
+	is.NoErr(Parse(cfg))
+	is.Equal("important", cfg.IsRequired)
 }
 
 func TestParseExpandOption(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		Host        string `env:"HOST" envDefault:"localhost"`
 		Port        int    `env:"PORT" envDefault:"3000" envExpand:"True"`
@@ -722,34 +718,37 @@ func TestParseExpandOption(t *testing.T) {
 	cfg := config{}
 	err := Parse(&cfg)
 
-	require.NoError(t, err)
-	require.Equal(t, "localhost", cfg.Host)
-	require.Equal(t, 3000, cfg.Port)
-	require.Equal(t, "qwerty12345", cfg.SecretKey)
-	require.Equal(t, "qwerty12345", cfg.ExpandKey)
-	require.Equal(t, "localhost:3000", cfg.CompoundKey)
-	require.Equal(t, "def1", cfg.Default)
+	is.NoErr(err)
+	is.Equal("localhost", cfg.Host)
+	is.Equal(3000, cfg.Port)
+	is.Equal("qwerty12345", cfg.SecretKey)
+	is.Equal("qwerty12345", cfg.ExpandKey)
+	is.Equal("localhost:3000", cfg.CompoundKey)
+	is.Equal("def1", cfg.Default)
 }
 
 func TestParseUnsetRequireOptions(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		Password string `env:"PASSWORD,unset,required"`
 	}
 	defer os.Clearenv()
 	cfg := config{}
 
-	require.EqualError(t, Parse(&cfg), `env: required environment variable "PASSWORD" is not set`)
-
+	isErrorWithMessage(t, Parse(&cfg), `env: required environment variable "PASSWORD" is not set`)
 	os.Setenv("PASSWORD", "superSecret")
-	require.NoError(t, Parse(&cfg))
+	is.NoErr(Parse(&cfg))
 
-	require.Equal(t, "superSecret", cfg.Password)
+	is.Equal("superSecret", cfg.Password)
 	unset, exists := os.LookupEnv("PASSWORD")
-	require.Equal(t, "", unset)
-	require.Equal(t, false, exists)
+	is.Equal("", unset)
+	is.Equal(false, exists)
 }
 
 func TestCustomParser(t *testing.T) {
+	is := is.New(t)
+
 	type foo struct {
 		name string
 	}
@@ -781,23 +780,21 @@ func TestCustomParser(t *testing.T) {
 		},
 	})
 
-	require.NoError(t, err)
-	require.Equal(t, cfg.Var.name, "test")
-	require.Equal(t, cfg.Foo.name, "test3")
-	require.Equal(t, cfg.Other.Name, "test2")
-	require.Equal(t, cfg.Other.Foo.name, "test3")
+	is.NoErr(err)
+	is.Equal(cfg.Var.name, "test")
+	is.Equal(cfg.Foo.name, "test3")
+	is.Equal(cfg.Other.Name, "test2")
+	is.Equal(cfg.Other.Foo.name, "test3")
 }
 
 func TestParseWithFuncsNoPtr(t *testing.T) {
 	type foo struct{}
-	err := ParseWithFuncs(foo{}, nil)
-	require.EqualError(t, err, "env: expected a pointer to a Struct")
+	isErrorWithMessage(t, ParseWithFuncs(foo{}, nil), "env: expected a pointer to a Struct")
 }
 
 func TestParseWithFuncsInvalidType(t *testing.T) {
 	var c int
-	err := ParseWithFuncs(&c, nil)
-	require.EqualError(t, err, "env: expected a pointer to a Struct")
+	isErrorWithMessage(t, ParseWithFuncs(&c, nil), "env: expected a pointer to a Struct")
 }
 
 func TestCustomParserError(t *testing.T) {
@@ -810,6 +807,8 @@ func TestCustomParserError(t *testing.T) {
 	}
 
 	t.Run("single", func(t *testing.T) {
+		is := is.New(t)
+
 		type config struct {
 			Var foo `env:"VAR"`
 		}
@@ -820,11 +819,13 @@ func TestCustomParserError(t *testing.T) {
 			reflect.TypeOf(foo{}): customParserFunc,
 		})
 
-		require.Empty(t, cfg.Var.name)
-		require.EqualError(t, err, "env: parse error on field \"Var\" of type \"env.foo\": something broke")
+		is.Equal(cfg.Var.name, "")
+		isErrorWithMessage(t, err, `env: parse error on field "Var" of type "env.foo": something broke`)
 	})
 
 	t.Run("slice", func(t *testing.T) {
+		is := is.New(t)
+
 		type config struct {
 			Var []foo `env:"VAR2"`
 		}
@@ -835,12 +836,14 @@ func TestCustomParserError(t *testing.T) {
 			reflect.TypeOf(foo{}): customParserFunc,
 		})
 
-		require.Empty(t, cfg.Var)
-		require.EqualError(t, err, "env: parse error on field \"Var\" of type \"[]env.foo\": something broke")
+		is.Equal(cfg.Var, nil)
+		isErrorWithMessage(t, err, `env: parse error on field "Var" of type "[]env.foo": something broke`)
 	})
 }
 
 func TestCustomParserBasicType(t *testing.T) {
+	is := is.New(t)
+
 	type ConstT int32
 
 	type config struct {
@@ -864,11 +867,13 @@ func TestCustomParserBasicType(t *testing.T) {
 		reflect.TypeOf(ConstT(0)): customParserFunc,
 	})
 
-	require.NoError(t, err)
-	require.Equal(t, exp, cfg.Const)
+	is.NoErr(err)
+	is.Equal(exp, cfg.Const)
 }
 
 func TestCustomParserUint64Alias(t *testing.T) {
+	is := is.New(t)
+
 	type T uint64
 
 	var one T = 1
@@ -895,12 +900,14 @@ func TestCustomParserUint64Alias(t *testing.T) {
 		reflect.TypeOf(one): tParser,
 	})
 
-	require.True(t, parserCalled, "tParser should have been called")
-	require.NoError(t, err)
-	require.Equal(t, T(1), cfg.Val)
+	is.True(parserCalled) // tParser should have been called
+	is.NoErr(err)
+	is.Equal(T(1), cfg.Val)
 }
 
 func TestTypeCustomParserBasicInvalid(t *testing.T) {
+	is := is.New(t)
+
 	type ConstT int32
 
 	type config struct {
@@ -918,11 +925,13 @@ func TestTypeCustomParserBasicInvalid(t *testing.T) {
 		reflect.TypeOf(ConstT(0)): customParserFunc,
 	})
 
-	require.Empty(t, cfg.Const)
-	require.EqualError(t, err, "env: parse error on field \"Const\" of type \"env.ConstT\": random error")
+	is.Equal(cfg.Const, ConstT(0))
+	isErrorWithMessage(t, err, `env: parse error on field "Const" of type "env.ConstT": random error`)
 }
 
 func TestCustomParserNotCalledForNonAlias(t *testing.T) {
+	is := is.New(t)
+
 	type T uint64
 	type U uint64
 
@@ -944,13 +953,15 @@ func TestCustomParserNotCalledForNonAlias(t *testing.T) {
 		reflect.TypeOf(T(0)): tParser,
 	})
 
-	require.False(t, tParserCalled, "tParser should not have been called")
-	require.NoError(t, err)
-	require.Equal(t, uint64(33), cfg.Val)
-	require.Equal(t, U(44), cfg.Other)
+	is.True(!tParserCalled) // tParser should not have been called
+	is.NoErr(err)
+	is.Equal(uint64(33), cfg.Val)
+	is.Equal(U(44), cfg.Other)
 }
 
 func TestCustomParserBasicUnsupported(t *testing.T) {
+	is := is.New(t)
+
 	type ConstT struct {
 		A int
 	}
@@ -964,24 +975,22 @@ func TestCustomParserBasicUnsupported(t *testing.T) {
 	cfg := &config{}
 	err := Parse(cfg)
 
-	require.Zero(t, cfg.Const)
-	require.EqualError(t, err, "env: no parser found for field \"Const\" of type \"env.ConstT\"")
+	is.Equal(cfg.Const, ConstT{0})
+	isErrorWithMessage(t, err, `env: no parser found for field "Const" of type "env.ConstT"`)
 }
 
 func TestUnsupportedStructType(t *testing.T) {
 	type config struct {
 		Foo http.Client `env:"FOO"`
 	}
-
 	os.Setenv("FOO", "foo")
-
-	cfg := &config{}
-	err := Parse(cfg)
-
-	require.EqualError(t, err, "env: no parser found for field \"Foo\" of type \"http.Client\"")
+	defer os.Clearenv()
+	isErrorWithMessage(t, Parse(&config{}), `env: no parser found for field "Foo" of type "http.Client"`)
 }
 
 func TestEmptyOption(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		Var string `env:"VAR,"`
 	}
@@ -990,17 +999,15 @@ func TestEmptyOption(t *testing.T) {
 
 	os.Setenv("VAR", "")
 	defer os.Clearenv()
-	require.NoError(t, Parse(cfg))
-	require.Equal(t, "", cfg.Var)
+	is.NoErr(Parse(cfg))
+	is.Equal("", cfg.Var)
 }
 
 func TestErrorOptionNotRecognized(t *testing.T) {
 	type config struct {
 		Var string `env:"VAR,not_supported!"`
 	}
-
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: tag option \"not_supported!\" not supported")
+	isErrorWithMessage(t, Parse(&config{}), `env: tag option "not_supported!" not supported`)
 }
 
 func TestTextUnmarshalerError(t *testing.T) {
@@ -1008,8 +1015,7 @@ func TestTextUnmarshalerError(t *testing.T) {
 		Unmarshaler unmarshaler `env:"UNMARSHALER"`
 	}
 	os.Setenv("UNMARSHALER", "invalid")
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"Unmarshaler\" of type \"env.unmarshaler\": time: invalid duration \"invalid\"")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "Unmarshaler" of type "env.unmarshaler": time: invalid duration "invalid"`)
 }
 
 func TestTextUnmarshalersError(t *testing.T) {
@@ -1017,26 +1023,27 @@ func TestTextUnmarshalersError(t *testing.T) {
 		Unmarshalers []unmarshaler `env:"UNMARSHALERS"`
 	}
 	os.Setenv("UNMARSHALERS", "1s,invalid")
-	cfg := &config{}
-	require.EqualError(t, Parse(cfg), "env: parse error on field \"Unmarshalers\" of type \"[]env.unmarshaler\": time: invalid duration \"invalid\"")
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "Unmarshalers" of type "[]env.unmarshaler": time: invalid duration "invalid"`)
 }
 
 func TestParseURL(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		ExampleURL url.URL `env:"EXAMPLE_URL" envDefault:"https://google.com"`
 	}
 	var cfg config
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, "https://google.com", cfg.ExampleURL.String())
+	is.NoErr(Parse(&cfg))
+	is.Equal("https://google.com", cfg.ExampleURL.String())
 }
 
 func TestParseInvalidURL(t *testing.T) {
 	type config struct {
 		ExampleURL url.URL `env:"EXAMPLE_URL_2"`
 	}
-	var cfg config
 	os.Setenv("EXAMPLE_URL_2", "nope://s s/")
-	require.EqualError(t, Parse(&cfg), "env: parse error on field \"ExampleURL\" of type \"url.URL\": unable to parse URL: parse \"nope://s s/\": invalid character \" \" in host name")
+
+	isErrorWithMessage(t, Parse(&config{}), `env: parse error on field "ExampleURL" of type "url.URL": unable to parse URL: parse "nope://s s/": invalid character " " in host name`)
 }
 
 func ExampleParse() {
@@ -1059,6 +1066,8 @@ func ExampleParse() {
 }
 
 func TestIgnoresUnexported(t *testing.T) {
+	is := is.New(t)
+
 	type unexportedConfig struct {
 		home  string `env:"HOME"`
 		Home2 string `env:"HOME"`
@@ -1066,9 +1075,9 @@ func TestIgnoresUnexported(t *testing.T) {
 	cfg := unexportedConfig{}
 
 	os.Setenv("HOME", "/tmp/fakehome")
-	require.NoError(t, Parse(&cfg))
-	require.Empty(t, cfg.home)
-	require.Equal(t, "/tmp/fakehome", cfg.Home2)
+	is.NoErr(Parse(&cfg))
+	is.Equal(cfg.home, "")
+	is.Equal("/tmp/fakehome", cfg.Home2)
 }
 
 type LogLevel int8
@@ -1093,6 +1102,8 @@ const (
 )
 
 func TestPrecedenceUnmarshalText(t *testing.T) {
+	is := is.New(t)
+
 	os.Setenv("LOG_LEVEL", "debug")
 	os.Setenv("LOG_LEVELS", "debug,info")
 	defer os.Unsetenv("LOG_LEVEL")
@@ -1104,9 +1115,9 @@ func TestPrecedenceUnmarshalText(t *testing.T) {
 	}
 	var cfg config
 
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, DebugLevel, cfg.LogLevel)
-	require.Equal(t, []LogLevel{DebugLevel, InfoLevel}, cfg.LogLevels)
+	is.NoErr(Parse(&cfg))
+	is.Equal(DebugLevel, cfg.LogLevel)
+	is.Equal([]LogLevel{DebugLevel, InfoLevel}, cfg.LogLevels)
 }
 
 func ExampleParseWithFuncs() {
@@ -1136,42 +1147,41 @@ func ExampleParseWithFuncs() {
 }
 
 func TestFile(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file"`
 	}
 
 	dir := t.TempDir()
 	file := filepath.Join(dir, "sec_key")
-	require.NoError(t, ioutil.WriteFile(file, []byte("secret"), 0o660))
+	is.NoErr(ioutil.WriteFile(file, []byte("secret"), 0o660))
 
 	defer os.Clearenv()
 	os.Setenv("SECRET_KEY", file)
 
 	cfg := config{}
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, "secret", cfg.SecretKey)
+	is.NoErr(Parse(&cfg))
+	is.Equal("secret", cfg.SecretKey)
 }
 
 func TestFileNoParam(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file"`
 	}
 	defer os.Clearenv()
 
 	cfg := config{}
-	require.NoError(t, Parse(&cfg))
+	is.NoErr(Parse(&cfg))
 }
 
 func TestFileNoParamRequired(t *testing.T) {
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file,required"`
 	}
-	defer os.Clearenv()
-	cfg := config{}
-	err := Parse(&cfg)
-
-	require.Error(t, err)
-	require.EqualError(t, err, "env: required environment variable \"SECRET_KEY\" is not set")
+	isErrorWithMessage(t, Parse(&config{}), `env: required environment variable "SECRET_KEY" is not set`)
 }
 
 func TestFileBadFile(t *testing.T) {
@@ -1183,18 +1193,16 @@ func TestFileBadFile(t *testing.T) {
 	defer os.Clearenv()
 	os.Setenv("SECRET_KEY", filename)
 
-	cfg := config{}
-	err := Parse(&cfg)
-
-	require.Error(t, err)
 	oserr := "no such file or directory"
 	if runtime.GOOS == "windows" {
 		oserr = "The system cannot find the file specified."
 	}
-	require.EqualError(t, err, fmt.Sprintf(`env: could not load content of file "%s" from variable SECRET_KEY: open %s: %s`, filename, filename, oserr))
+	isErrorWithMessage(t, Parse(&config{}), fmt.Sprintf(`env: could not load content of file "%s" from variable SECRET_KEY: open %s: %s`, filename, filename, oserr))
 }
 
 func TestFileWithDefault(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		SecretKey string `env:"SECRET_KEY,file" envDefault:"${FILE}" envExpand:"true"`
 	}
@@ -1202,17 +1210,19 @@ func TestFileWithDefault(t *testing.T) {
 
 	dir := t.TempDir()
 	file := filepath.Join(dir, "sec_key")
-	require.NoError(t, ioutil.WriteFile(file, []byte("secret"), 0o660))
+	is.NoErr(ioutil.WriteFile(file, []byte("secret"), 0o660))
 
 	defer os.Clearenv()
 	os.Setenv("FILE", file)
 
 	cfg := config{}
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, "secret", cfg.SecretKey)
+	is.NoErr(Parse(&cfg))
+	is.Equal("secret", cfg.SecretKey)
 }
 
 func TestCustomSliceType(t *testing.T) {
+	is := is.New(t)
+
 	type customslice []byte
 
 	type config struct {
@@ -1227,11 +1237,12 @@ func TestCustomSliceType(t *testing.T) {
 	os.Setenv("SECRET_KEY", "somesecretkey")
 
 	var cfg config
-	err := ParseWithFuncs(&cfg, map[reflect.Type]ParserFunc{reflect.TypeOf(customslice{}): parsecustomsclice})
-	require.NoError(t, err)
+	is.NoErr(ParseWithFuncs(&cfg, map[reflect.Type]ParserFunc{reflect.TypeOf(customslice{}): parsecustomsclice}))
 }
 
 func TestBlankKey(t *testing.T) {
+	is := is.New(t)
+
 	type testStruct struct {
 		Blank        string
 		BlankWithTag string `env:""`
@@ -1242,11 +1253,9 @@ func TestBlankKey(t *testing.T) {
 	defer os.Clearenv()
 	os.Setenv("", "You should not see this")
 
-	err := Parse(&val)
-	require.NoError(t, err)
-
-	require.Equal(t, "", val.Blank)
-	require.Equal(t, "", val.BlankWithTag)
+	is.NoErr(Parse(&val))
+	is.Equal("", val.Blank)
+	is.Equal("", val.BlankWithTag)
 }
 
 type MyTime time.Time
@@ -1258,6 +1267,8 @@ func (t *MyTime) UnmarshalText(text []byte) error {
 }
 
 func TestCustomTimeParser(t *testing.T) {
+	is := is.New(t)
+
 	type config struct {
 		SomeTime MyTime `env:"SOME_TIME"`
 	}
@@ -1266,8 +1277,16 @@ func TestCustomTimeParser(t *testing.T) {
 	defer os.Unsetenv("SOME_TIME")
 
 	var cfg config
-	require.NoError(t, Parse(&cfg))
-	require.Equal(t, 2021, time.Time(cfg.SomeTime).Year())
-	require.Equal(t, time.Month(5), time.Time(cfg.SomeTime).Month())
-	require.Equal(t, 6, time.Time(cfg.SomeTime).Day())
+	is.NoErr(Parse(&cfg))
+	is.Equal(2021, time.Time(cfg.SomeTime).Year())
+	is.Equal(time.Month(5), time.Time(cfg.SomeTime).Month())
+	is.Equal(6, time.Time(cfg.SomeTime).Day())
+}
+
+func isErrorWithMessage(tb testing.TB, err error, msg string) {
+	tb.Helper()
+
+	is := is.New(tb)
+	is.True(err != nil)        // should have failed
+	is.Equal(err.Error(), msg) // should have the expected message
 }

--- a/env_windows_test.go
+++ b/env_windows_test.go
@@ -3,15 +3,16 @@ package env
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/matryer/is"
 )
 
 // On Windows, environment variables can start with '='. This test verifies this behavior without relying on a Windows environment.
 // See env_windows.go in the Go source: https://github.com/golang/go/blob/master/src/syscall/env_windows.go#L58
 func TestToMapWindows(t *testing.T) {
+	is := is.New()
 	envVars := []string{"=::=::\\", "=C:=C:\\test", "VAR=REGULARVAR"}
 	result := toMap(envVars)
-	require.Equal(t, map[string]string{
+	is.Equal(map[string]string{
 		"=::": "::\\",
 		"=C:": "C:\\test",
 		"VAR": "REGULARVAR",

--- a/env_windows_test.go
+++ b/env_windows_test.go
@@ -9,7 +9,7 @@ import (
 // On Windows, environment variables can start with '='. This test verifies this behavior without relying on a Windows environment.
 // See env_windows.go in the Go source: https://github.com/golang/go/blob/master/src/syscall/env_windows.go#L58
 func TestToMapWindows(t *testing.T) {
-	is := is.New()
+	is := is.New(t)
 	envVars := []string{"=::=::\\", "=C:=C:\\test", "VAR=REGULARVAR"}
 	result := toMap(envVars)
 	is.Equal(map[string]string{

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/caarlos0/env/v6
 
-require github.com/stretchr/testify v1.7.0
+require github.com/matryer/is v1.4.0
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,2 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
+github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=


### PR DESCRIPTION
the idea is to lower the number of dependencies.

matryer's `is` has no dependencies, which is IMHO great for a library like `env`, which aims to be "minimal but effective".