### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/env.go
+++ b/env.go
@@ -4,7 +4,6 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
@@ -299,7 +298,7 @@ func parseKeyForOption(key string) (string, []string) {
 }
 
 func getFromFile(filename string) (value string, err error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	return string(b), err
 }
 

--- a/env_test.go
+++ b/env_test.go
@@ -3,7 +3,6 @@ package env
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -1248,7 +1247,7 @@ func TestFile(t *testing.T) {
 
 	dir := t.TempDir()
 	file := filepath.Join(dir, "sec_key")
-	is.NoErr(ioutil.WriteFile(file, []byte("secret"), 0o660))
+	is.NoErr(os.WriteFile(file, []byte("secret"), 0o660))
 
 	defer os.Clearenv()
 	os.Setenv("SECRET_KEY", file)
@@ -1303,7 +1302,7 @@ func TestFileWithDefault(t *testing.T) {
 
 	dir := t.TempDir()
 	file := filepath.Join(dir, "sec_key")
-	is.NoErr(ioutil.WriteFile(file, []byte("secret"), 0o660))
+	is.NoErr(os.WriteFile(file, []byte("secret"), 0o660))
 
 	defer os.Clearenv()
 	os.Setenv("FILE", file)


### PR DESCRIPTION
The io/ioutil package has been deprecated as of Go 1.16.
See https://golang.org/doc/go1.16#ioutil