### PR TITLE
feat: Add option: 'required' by default

### DIFF
--- a/env.go
+++ b/env.go
@@ -101,6 +101,8 @@ type Options struct {
 	Environment map[string]string
 	// TagName specifies another tagname to use rather than the default env.
 	TagName string
+	// RequiredIfNoDef automatically sets all env as required if they do not declare 'envDefault'
+	RequiredIfNoDef bool
 
 	// Sets to true if we have already configured once.
 	configured bool
@@ -130,6 +132,7 @@ func configure(opts []Options) []Options {
 		if item.TagName != "" {
 			opt.TagName = item.TagName
 		}
+		opt.RequiredIfNoDef = item.RequiredIfNoDef
 	}
 
 	return []Options{opt}
@@ -215,7 +218,7 @@ func doParse(ref reflect.Value, funcMap map[reflect.Type]ParserFunc, opts []Opti
 }
 
 func get(field reflect.StructField, opts []Options) (val string, err error) {
-	var required bool
+	var required bool = opts[0].RequiredIfNoDef
 	var exists bool
 	var loadFile bool
 	var unset bool

--- a/env_test.go
+++ b/env_test.go
@@ -1321,6 +1321,24 @@ func TestCustomTimeParser(t *testing.T) {
 	is.Equal(6, time.Time(cfg.SomeTime).Day())
 }
 
+func TestRequiredIfNoDefOption(t *testing.T) {
+	is := is.New(t)
+
+	type config struct {
+		Name  string `env:"NAME"`
+		Genre string `env:"GENRE" envDefault:"Unknown"`
+	}
+
+	var cfg config
+	is.NoErr(Parse(&cfg))
+	isErrorWithMessage(t, Parse(&cfg, Options{RequiredIfNoDef: true}), `env: required environment variable "NAME" is not set`)
+
+	os.Setenv("NAME", "John")
+	defer os.Clearenv()
+	// should not trigger an error for the missing 'GENRE' env because it has a default value.
+	is.NoErr(Parse(&cfg, Options{RequiredIfNoDef: true}))
+}
+
 func isErrorWithMessage(tb testing.TB, err error, msg string) {
 	tb.Helper()
 


### PR DESCRIPTION
Changes
===
- Add a new option `RequiredIfNoDef` that mark all field `,required` by default.

Why
===
In most of my projects, environement variables are either required or have default values. 
Adding this option allow to remove a redundant (and sometimes obvious) `,required` in field tags.