### PR TITLE
fix: error in embedded struct when using option RequiredIfNoDef:true

### DIFF
--- a/env.go
+++ b/env.go
@@ -270,7 +270,7 @@ func get(field reflect.StructField, opts []Options) (val string, err error) {
 		defer os.Unsetenv(key)
 	}
 
-	if required && !exists {
+	if required && !exists && len(key) > 0 {
 		return "", fmt.Errorf(`env: required environment variable %q is not set`, key)
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -1377,18 +1377,26 @@ func TestCustomTimeParser(t *testing.T) {
 }
 
 func TestRequiredIfNoDefOption(t *testing.T) {
+	type Tree struct {
+		Fruit string `env:"FRUIT"`
+	}
 	type config struct {
 		Name  string `env:"NAME"`
 		Genre string `env:"GENRE" envDefault:"Unknown"`
+		Tree
 	}
 	var cfg config
 
 	t.Run("missing", func(t *testing.T) {
 		isErrorWithMessage(t, Parse(&cfg, Options{RequiredIfNoDef: true}), `env: required environment variable "NAME" is not set`)
+		os.Setenv("NAME", "John")
+		t.Cleanup(os.Clearenv)
+		isErrorWithMessage(t, Parse(&cfg, Options{RequiredIfNoDef: true}), `env: required environment variable "FRUIT" is not set`)
 	})
 
 	t.Run("all set", func(t *testing.T) {
 		os.Setenv("NAME", "John")
+		os.Setenv("FRUIT", "Apple")
 		t.Cleanup(os.Clearenv)
 
 		// should not trigger an error for the missing 'GENRE' env because it has a default value.


### PR DESCRIPTION
This PR follows my [previous one](https://github.com/caarlos0/env/pull/187) and fix an issue I spoted when using the option with embedded structs.

Changes
===
- Fix issue causing parse to fail on embedded struct when using `RequiredIfNoDef` option.
- Updated test related to `RequiredIfNoDef` option.