### PR TITLE
fix: pass prefix on anonymous struct

### DIFF
--- a/env.go
+++ b/env.go
@@ -216,7 +216,7 @@ func doParse(ref reflect.Value, funcMap map[reflect.Type]ParserFunc, opts []Opti
 			continue
 		}
 		if reflect.Struct == refField.Kind() && refField.CanAddr() && refField.Type().Name() == "" {
-			if err := Parse(refField.Addr().Interface(), opts...); err != nil {
+			if err := Parse(refField.Addr().Interface(), optsWithPrefix(refType.Field(i), opts)...); err != nil {
 				return err
 			}
 			continue


### PR DESCRIPTION
i wrote a nested anonymouse struct config object like this:

```
type Config struct {
  DB struct {
    Master string `env:"MASTER"`
  } `envPrefix:"DB_"`
}
```

but env failed to parse the `DB_MASTER` env variable. after investigation, I found a recursive call in the doParse() func missed passing a prefix to the opt argument, cause.

this PR wraps a `optsWithPrefix` on calling `Parse` recursively, so the `Parse` function can get the prefix which defined in the `envPrefix` tag.

the tests have been passed, but I dunno if this change could introduce any side effect or not. Thank you for advice!

regards