### PR TITLE
feat: option to ignore default value tag

### DIFF
--- a/env.go
+++ b/env.go
@@ -114,7 +114,7 @@ type Options struct {
 	// Prefix define a prefix for each key
 	Prefix string
 
-	// Ignore envDefault tags
+	// Ignore all envDefault tags
 	IgnoreDefault bool
 
 	// Sets to true if we have already configured once.

--- a/env_test.go
+++ b/env_test.go
@@ -1361,6 +1361,17 @@ func TestRequiredIfNoDefOption(t *testing.T) {
 	})
 }
 
+func TestIgnoreDefaultOption(t *testing.T) {
+
+	type config struct {
+		SomeValue string `env:"SOME_VALUE" envDefault:"value"`
+	}
+
+	var cfg config
+	isNoErr(t, Parse(&cfg, Options{IgnoreDefault: true}))
+	isEqual(t, "", cfg.SomeValue)
+}
+
 func TestPrefix(t *testing.T) {
 	type Config struct {
 		Home string `env:"HOME"`


### PR DESCRIPTION
This PR adds a new option field IgnoreDefault that if it's true, the tags envDefault will be ignored completely.

## Motivation

When working with configuration structs, sometimes we do want to use default for local envs in order not to provide lots of configurations during development while in production those defaults must not be used. We can use the existing OnSet function and panic in case of a default but sometimes it is too aggressive and we just want to simply ignore those defaults.