### PR TITLE
feat: Add optional flag

### DIFF
--- a/env.go
+++ b/env.go
@@ -260,6 +260,8 @@ func get(field reflect.StructField, opts []Options) (val string, err error) {
 			loadFile = true
 		case "required":
 			required = true
+		case "optional":
+			required = false
 		case "unset":
 			unset = true
 		case "notEmpty":

--- a/env_test.go
+++ b/env_test.go
@@ -1338,8 +1338,9 @@ func TestRequiredIfNoDefOption(t *testing.T) {
 		Fruit string `env:"FRUIT"`
 	}
 	type config struct {
-		Name  string `env:"NAME"`
-		Genre string `env:"GENRE" envDefault:"Unknown"`
+		Name     string `env:"NAME"`
+		Category string `env:"CATEGORY,optional"`
+		Genre    string `env:"GENRE" envDefault:"Unknown"`
 		Tree
 	}
 	var cfg config
@@ -1357,6 +1358,7 @@ func TestRequiredIfNoDefOption(t *testing.T) {
 		t.Cleanup(os.Clearenv)
 
 		// should not trigger an error for the missing 'GENRE' env because it has a default value.
+		// should not trigger an error for the missing 'CATEGORY' as it is set as optional.
 		isNoErr(t, Parse(&cfg, Options{RequiredIfNoDef: true}))
 	})
 }


### PR DESCRIPTION
Resolves https://github.com/caarlos0/env/issues/209

This PR adds an optional flag so that way `RequiredIfNoDef` can ignore the fields as required. It is a bit cleaner than having a bunch of `envDefault:""`s in my opinion. 

I added it to the `TestRequiredIfNoDefOption`, however if you want more tests let me know and I can add them.