### PR TITLE
refactor: remove unnecessary line

### DIFF
--- a/env.go
+++ b/env.go
@@ -453,9 +453,6 @@ func parseTextUnmarshalers(field reflect.Value, data []string, sf reflect.Struct
 }
 
 func newParseError(sf reflect.StructField, err error) error {
-	if err == nil {
-		return nil
-	}
 	return parseError{
 		sf:  sf,
 		err: err,


### PR DESCRIPTION
* `nil` check line removed from the `newParserError`function. Because it is called from other functions after checking the `err` whether its value is `nil`. That's why no need to check it again inside the function.

* This change will also increase the code coverage from 98.2% to 98.7% with Go's code coverage metrics.

* This line is one of the two uncovered lines wrt [codecov](https://app.codecov.io/gh/caarlos0/env/blob/main/env.go).

Signed-off-by: Gökhan Özeloğlu <gozeloglu@gmail.com>