### PR TITLE
Feat/custom loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ You can change what tag name to use for setting the env vars by setting the `Opt
 variable.
 
 For example
+
 ```go
 package main
 
@@ -451,6 +452,43 @@ func main() {
 	}
 
 	fmt.Printf("%+v", cfg)  // {Username:admin Password:123456}
+}
+```
+
+## Custom Loaders
+
+You may want to load value from a custom location or make some changes before filling the config value.
+Loaders will retrieve the string value and send it to the parser to deal with it.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/caarlos0/env/v6"
+)
+
+type Config struct {
+		DatabaseURI string `env:"DATABASE_URI,secret"`
+}
+
+
+func main() {
+	opts := Options{
+		CustomLoaders: map[string]LoaderFunc{
+			"secret": func(key string) (string, error) {
+				//Do anything to retrieve the value based on the key
+				return "jdbc:mydb://root:123@127.0.0.1/test", nil
+			},
+		},
+	}
+	var cfg config
+
+	if err := env.Parse(&cfg, opts); err != nil {
+		fmt.Println("failed:", err)
+	}
+	fmt.Printf("%+v", cfg)  // {DatabaseURI:"jdbc:mydb://root:123@127.0.0.1/test"}
 }
 ```
 


### PR DESCRIPTION
I faced a scenario where some of my configs are not stored at env, but in a secret place that requires an API connection to retrieve them.

So I modified the get method to accept custom loaders and retrieve strings from anywhere.

It should be useful if you want to load value from a custom location or make some changes before filling the config value.

Loaders will retrieve the string value and send it to the parser to deal with it very similar to the file loader.

Example usage:

```go
package main

import (
	"fmt"

	"github.com/caarlos0/env/v6"
)

type Config struct {
		DatabaseURI string `env:"DATABASE_URI,secret"`
}


func main() {
	opts := Options{
		CustomLoaders: map[string]LoaderFunc{
			"secret": func(key string) (string, error) {
				// Do anything to retrieve the value based on the key
				// Ex: aws secret retriveral, redis, .ini/.yaml file parsing etc
				return "jdbc:mydb://root:123@127.0.0.1/test", nil
			},
		},
	}
	var cfg config

	if err := env.Parse(&cfg, opts); err != nil {
		fmt.Println("failed:", err)
	}
	fmt.Printf("%+v", cfg)  // {DatabaseURI:"jdbc:mydb://root:123@127.0.0.1/test"}
}
```