### PR TITLE
fix: custom parsers with anon inner structs

### DIFF
--- a/env.go
+++ b/env.go
@@ -218,7 +218,7 @@ func doParse(ref reflect.Value, funcMap map[reflect.Type]ParserFunc, opts []Opti
 			continue
 		}
 		if reflect.Struct == refField.Kind() && refField.CanAddr() && refField.Type().Name() == "" {
-			if err := Parse(refField.Addr().Interface(), optsWithPrefix(refType.Field(i), opts)...); err != nil {
+			if err := ParseWithFuncs(refField.Addr().Interface(), funcMap, optsWithPrefix(refType.Field(i), opts)...); err != nil {
 				return err
 			}
 			continue

--- a/env_test.go
+++ b/env_test.go
@@ -799,6 +799,22 @@ func TestCustomParser(t *testing.T) {
 	}
 }
 
+func TestIssue226(t *testing.T) {
+	type config struct {
+		Inner struct {
+			Abc []byte `env:"ABC" envDefault:"asdasd"`
+		}
+	}
+
+	cfg := &config{}
+	isNoErr(t, ParseWithFuncs(cfg, map[reflect.Type]ParserFunc{
+		reflect.TypeOf([]byte{0}): func(v string) (interface{}, error) {
+			return []byte(v), nil
+		},
+	}))
+	isEqual(t, cfg.Inner.Abc, []byte("asdasd"))
+}
+
 func TestParseWithFuncsNoPtr(t *testing.T) {
 	type foo struct{}
 	isErrorWithMessage(t, ParseWithFuncs(foo{}, nil), "env: expected a pointer to a Struct")

--- a/env_test.go
+++ b/env_test.go
@@ -801,12 +801,16 @@ func TestCustomParser(t *testing.T) {
 
 func TestIssue226(t *testing.T) {
 	type config struct {
-		Ghi   []byte `env:"Ghi" envDefault:"a"`
 		Inner struct {
 			Abc []byte `env:"ABC" envDefault:"asdasd"`
 			Def []byte `env:"DEF" envDefault:"a"`
 		}
+		Hij []byte `env:"HIJ"`
+		Lmn []byte `env:"LMN"`
 	}
+
+	setEnv(t, "HIJ", "a")
+	setEnv(t, "LMN", "b")
 
 	cfg := &config{}
 	isNoErr(t, ParseWithFuncs(cfg, map[reflect.Type]ParserFunc{
@@ -819,7 +823,8 @@ func TestIssue226(t *testing.T) {
 	}))
 	isEqual(t, cfg.Inner.Abc, []byte("asdasd"))
 	isEqual(t, cfg.Inner.Def, []byte("nope"))
-	isEqual(t, cfg.Ghi, []byte("nope"))
+	isEqual(t, cfg.Hij, []byte("nope"))
+	isEqual(t, cfg.Lmn, []byte("b"))
 }
 
 func TestParseWithFuncsNoPtr(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -801,18 +801,25 @@ func TestCustomParser(t *testing.T) {
 
 func TestIssue226(t *testing.T) {
 	type config struct {
+		Ghi   []byte `env:"Ghi" envDefault:"a"`
 		Inner struct {
 			Abc []byte `env:"ABC" envDefault:"asdasd"`
+			Def []byte `env:"DEF" envDefault:"a"`
 		}
 	}
 
 	cfg := &config{}
 	isNoErr(t, ParseWithFuncs(cfg, map[reflect.Type]ParserFunc{
 		reflect.TypeOf([]byte{0}): func(v string) (interface{}, error) {
+			if v == "a" {
+				return []byte("nope"), nil
+			}
 			return []byte(v), nil
 		},
 	}))
 	isEqual(t, cfg.Inner.Abc, []byte("asdasd"))
+	isEqual(t, cfg.Inner.Def, []byte("nope"))
+	isEqual(t, cfg.Ghi, []byte("nope"))
 }
 
 func TestParseWithFuncsNoPtr(t *testing.T) {


### PR DESCRIPTION
fixes #226 

it was not passing down the funcmap to the children anon structs, which was causing a weird error in this particular case.