### PR TITLE
fix: RequiredIfNoDef with nested structs

### DIFF
--- a/env.go
+++ b/env.go
@@ -252,8 +252,8 @@ func get(field reflect.StructField, opts []Options) (val string, err error) {
 
 	required := opts[0].RequiredIfNoDef
 	prefix := opts[0].Prefix
-	key, tags := parseKeyForOption(field.Tag.Get(getTagName(opts)))
-	key = prefix + key
+	ownKey, tags := parseKeyForOption(field.Tag.Get(getTagName(opts)))
+	key := prefix + ownKey
 	for _, tag := range tags {
 		switch tag {
 		case "":
@@ -282,7 +282,7 @@ func get(field reflect.StructField, opts []Options) (val string, err error) {
 		defer os.Unsetenv(key)
 	}
 
-	if required && !exists && len(key) > 0 {
+	if required && !exists && len(ownKey) > 0 {
 		return "", fmt.Errorf(`env: required environment variable %q is not set`, key)
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -1344,6 +1344,37 @@ func TestRequiredIfNoDefOption(t *testing.T) {
 	})
 }
 
+func TestRequiredIfNoDefNested(t *testing.T) {
+	type Server struct {
+		Host string `env:"HOST"`
+		Port uint16 `env:"PORT"`
+	}
+	type API struct {
+		Server
+		Token string `env:"TOKEN"`
+	}
+	type config struct {
+		API API `envPrefix:"SERVER_"`
+	}
+	var cfg config
+
+	t.Run("missing", func(t *testing.T) {
+		setEnv(t, "SERVER_HOST", "https://google.com")
+		setEnv(t, "SERVER_TOKEN", "0xdeadfood")
+
+		isErrorWithMessage(t, Parse(&cfg, Options{RequiredIfNoDef: true}), `env: required environment variable "SERVER_PORT" is not set`)
+	})
+
+	t.Run("all set", func(t *testing.T) {
+		setEnv(t, "SERVER_HOST", "https://google.com")
+		setEnv(t, "SERVER_PORT", "443")
+		setEnv(t, "SERVER_TOKEN", "0xdeadfood")
+
+		isNoErr(t, Parse(&cfg, Options{RequiredIfNoDef: true}))
+	})
+
+}
+
 func TestPrefix(t *testing.T) {
 	type Config struct {
 		Home string `env:"HOME"`

--- a/env_test.go
+++ b/env_test.go
@@ -1372,7 +1372,6 @@ func TestRequiredIfNoDefNested(t *testing.T) {
 
 		isNoErr(t, Parse(&cfg, Options{RequiredIfNoDef: true}))
 	})
-
 }
 
 func TestPrefix(t *testing.T) {


### PR DESCRIPTION
## Fix summary
I think, we simply need to check not if the `key` (which is `prefix + key`) is empty, but if the `key` itself. For this, I introduced variable `ownKey`. All other usages of `key` remained the same. All tests have passed and I added my own test to cover this bug.