### PR TITLE
Fix non empty struct pointer value

### DIFF
--- a/env.go
+++ b/env.go
@@ -226,12 +226,8 @@ func doParseField(refField reflect.Value, refTypeField reflect.StructField, func
 	if !refField.CanSet() {
 		return nil
 	}
-	if reflect.Ptr == refField.Kind() && !refField.IsNil() {
-		if refField.Elem().Kind() == reflect.Struct {
-			return ParseWithFuncs(refField.Interface(), funcMap, optsWithPrefix(refTypeField, opts)...)
-		}
-
-		return ParseWithFuncs(refField.Interface(), funcMap, opts...)
+	if reflect.Ptr == refField.Kind() && refField.Elem().Kind() == reflect.Struct {
+		return ParseWithFuncs(refField.Interface(), funcMap, optsWithPrefix(refTypeField, opts)...)
 	}
 	if reflect.Struct == refField.Kind() && refField.CanAddr() && refField.Type().Name() == "" {
 		return ParseWithFuncs(refField.Addr().Interface(), funcMap, optsWithPrefix(refTypeField, opts)...)

--- a/env_test.go
+++ b/env_test.go
@@ -1475,6 +1475,52 @@ func TestComplePrefix(t *testing.T) {
 	isEqual(t, "blahhh", cfg.Blah)
 }
 
+func TestNonStructPtrValues(t *testing.T) {
+	type Foo struct {
+		FltPtr *float64 `env:"FLT_PRT"`
+	}
+
+	type ComplexConfig struct {
+		StrPtr *string `env:"STR_PTR"`
+		Foo    Foo     `env:"FOO_"`
+	}
+
+	cfg1 := ComplexConfig{}
+
+	isNoErr(t, Parse(&cfg1))
+	isEqual(t, nil, cfg1.StrPtr)
+	isEqual(t, nil, cfg1.Foo.FltPtr)
+
+	strPtr := "str_ptr"
+	fltPtr := 3.16
+	cfg2 := ComplexConfig{
+		StrPtr: &strPtr,
+		Foo: Foo{
+			FltPtr: &fltPtr,
+		},
+	}
+
+	setEnv(t, "STR_PTR", "env_str_ptr")
+	setEnv(t, "FLT_PRT", "5.16")
+
+	isNoErr(t, Parse(&cfg2))
+	isEqual(t, "env_str_ptr", *cfg2.StrPtr)
+	isEqual(t, 5.16, *cfg2.Foo.FltPtr)
+
+	var strPtrNill *string
+	var fltPtrNill *float64
+	cfg3 := ComplexConfig{
+		StrPtr: strPtrNill,
+		Foo: Foo{
+			FltPtr: fltPtrNill,
+		},
+	}
+
+	isNoErr(t, Parse(&cfg3))
+	isEqual(t, "env_str_ptr", *cfg3.StrPtr)
+	isEqual(t, 5.16, *cfg3.Foo.FltPtr)
+}
+
 func isTrue(tb testing.TB, b bool) {
 	tb.Helper()
 


### PR DESCRIPTION
This is a fix for the bug #235 

I can't understand the purpose of condition !refField.IsNil() but for this use case it was considering it as non empty value (line 229), calling ParseWithFuncs (line 234) and failing due to non struct type (line 190).

I have removed it and added extra tests for that use case and all UTs are ok

@caarlos0  can you please take a look?