### PR TITLE
Fix minor typo in readme file?

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ type config struct {
 
 ## Not Empty fields
 
-While `required` demands the environment variable to be check, it doesn't check its value.
+While `required` demands the environment variable to be set, it doesn't check its value.
 If you want to make sure the environment is set and not empty, you need to use the `notEmpty` tag option instead (`env:"SOME_ENV,notEmpty"`).
 
 Example:


### PR DESCRIPTION
I'm not sure if this is just a typo but I think the following was intended.

Change the explanation of required tag from:

>  While `required` demands the environment variable to be check, it doesn't check its value.

to:

>  While `required` demands the environment variable to be set, it doesn't check its value.

Thanks for "env".