### PR TITLE
feat!: set default if var is set but empty

### DIFF
--- a/env.go
+++ b/env.go
@@ -325,6 +325,8 @@ func getOr(key, defaultValue string, defExists bool, envs map[string]string) (st
 	switch {
 	case (!exists || key == "") && defExists:
 		return defaultValue, true, true
+	case exists && value == "" && defExists:
+		return defaultValue, true, true
 	case !exists:
 		return "", false, false
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -153,6 +153,16 @@ type NestedStruct struct {
 	NestedVar string `env:"nestedvar"`
 }
 
+func TestIssue245(t *testing.T) {
+	t.Setenv("NAME_NOT_SET", "")
+	type user struct {
+		Name string `env:"NAME_NOT_SET" envDefault:"abcd"`
+	}
+	cfg := user{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, cfg.Name, "abcd")
+}
+
 func TestParsesEnv(t *testing.T) {
 	tos := func(v interface{}) string {
 		return fmt.Sprintf("%v", v)
@@ -671,7 +681,7 @@ func TestErrorRequiredWithDefault(t *testing.T) {
 
 	t.Setenv("IS_REQUIRED", "")
 	isNoErr(t, Parse(cfg))
-	isEqual(t, "", cfg.IsRequired)
+	isEqual(t, "important", cfg.IsRequired)
 }
 
 func TestErrorRequiredNotSet(t *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: before this, env would set the default value for a variable only if the variable was never set, and would do nothing if it was set to an empty value. After this, it will set the default value if empty as well.

closes #245