### PR TITLE
fix: invalid environment variable

### DIFF
--- a/env_tomap.go
+++ b/env_tomap.go
@@ -8,7 +8,9 @@ func toMap(env []string) map[string]string {
 	r := map[string]string{}
 	for _, e := range env {
 		p := strings.SplitN(e, "=", 2)
-		r[p[0]] = p[1]
+		if len(p) == 2 {
+			r[p[0]] = p[1]
+		}
 	}
 	return r
 }

--- a/env_tomap_test.go
+++ b/env_tomap_test.go
@@ -5,11 +5,12 @@ package env
 import "testing"
 
 func TestUnix(t *testing.T) {
-	envVars := []string{":=/test/unix", "PATH=:/test_val1:/test_val2", "VAR=REGULARVAR"}
+	envVars := []string{":=/test/unix", "PATH=:/test_val1:/test_val2", "VAR=REGULARVAR", "FOO=", "BAR"}
 	result := toMap(envVars)
 	isEqual(t, map[string]string{
 		":":    "/test/unix",
 		"PATH": ":/test_val1:/test_val2",
 		"VAR":  "REGULARVAR",
+		"FOO":  "",
 	}, result)
 }

--- a/env_tomap_windows.go
+++ b/env_tomap_windows.go
@@ -21,7 +21,9 @@ func toMap(env []string) map[string]string {
 			p[0] = "=" + p[0]
 		}
 
-		r[p[0]] = p[1]
+		if len(p) == 2 {
+			r[p[0]] = p[1]
+		}
 	}
 	return r
 }

--- a/env_tomap_windows_test.go
+++ b/env_tomap_windows_test.go
@@ -7,11 +7,12 @@ import "testing"
 // On Windows, environment variables can start with '='. This test verifies this behavior without relying on a Windows environment.
 // See env_windows.go in the Go source: https://github.com/golang/go/blob/master/src/syscall/env_windows.go#L58
 func TestToMapWindows(t *testing.T) {
-	envVars := []string{"=::=::\\", "=C:=C:\\test", "VAR=REGULARVAR"}
+	envVars := []string{"=::=::\\", "=C:=C:\\test", "VAR=REGULARVAR", "FOO=", "BAR"}
 	result := toMap(envVars)
 	isEqual(t, map[string]string{
 		"=::": "::\\",
 		"=C:": "C:\\test",
 		"VAR": "REGULARVAR",
+		"FOO": "",
 	}, result)
 }


### PR DESCRIPTION
Check the validity of environment variables when splitting variables by `=`. Ignore environment variables that don't include an `=` sign.