### PR TITLE
ParseWithOptions: add the ability to override defaultTypeParsers

### DIFF
--- a/env.go
+++ b/env.go
@@ -141,7 +141,9 @@ func customOptions(opt Options) Options {
 		opt.FuncMap = map[reflect.Type]ParserFunc{}
 	}
 	for k, v := range defOpts.FuncMap {
-		opt.FuncMap[k] = v
+		if _, exists := opt.FuncMap[k]; !exists {
+			opt.FuncMap[k] = v
+		}
 	}
 	return opt
 }

--- a/env_test.go
+++ b/env_test.go
@@ -1814,3 +1814,23 @@ func isNil(object interface{}) bool {
 	}
 	return false
 }
+
+func TestParseWithOptionsOverride(t *testing.T) {
+	type config struct {
+		Interval time.Duration `env:"INTERVAL"`
+	}
+
+	t.Setenv("INTERVAL", "1")
+
+	var cfg config
+
+	isNoErr(t, ParseWithOptions(&cfg, Options{FuncMap: map[reflect.Type]ParserFunc{
+		reflect.TypeOf(time.Nanosecond): func(value string) (interface{}, error) {
+			intervalI, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, err
+			}
+			return time.Duration(intervalI), nil
+		},
+	}}))
+}


### PR DESCRIPTION
This small fix/feature adds the ability to override default **ParserFunc** in **Options{FuncMap}** for **ParseWithOptions**

**When it can be useful:**
When for some reason you can't use default **ParseDuration** format but want to have a **time.Duration**
Like today I ran into a small but very annoying problem
I had some executions like `INTERVAL=1 ./script.sh` and wanted to override **time.Duration** parser but it was not possible. 
We may also want to override the **URL** parser or some other future **defaultTypeParsers** 



