### PR TITLE
Add a new option to allow overriding a default with an empty value

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -1548,6 +1548,17 @@ func TestCustomTimeParser(t *testing.T) {
 	isEqual(t, 6, time.Time(cfg.SomeTime).Day())
 }
 
+func TestEmptyValueOverridesDefaultOption(t *testing.T) {
+	type config struct {
+		Empty string `env:"EMPTY" envDefault:"foo"`
+	}
+
+	t.Setenv("EMPTY", "")
+	cfg := config{}
+	isNoErr(t, ParseWithOptions(&cfg, Options{EmptyValueOverridesDefault: true}))
+	isEqual(t, "", cfg.Empty)
+}
+
 func TestRequiredIfNoDefOption(t *testing.T) {
 	type Tree struct {
 		Fruit string `env:"FRUIT"`


### PR DESCRIPTION
For an example, see the test contained in this PR.

I've decided to add an option in order to avoid breaking changes. The default is `false``, causing it to behave like it already did before.