### PR TITLE
feat: custom key value separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ If you set the `envDefault` tag for something, this value will be used in the
 case of absence of it in the environment.
 
 By default, slice types will split the environment value on `,`; you can change
-this behavior by setting the `envSeparator` tag.
+this behavior by setting the `envSeparator` tag. For map types, the default
+separator between key and value is `:` and `,` for key-value pairs.
+The behavior can be changed by setting the `envKeyValSeparator` and 
+`envSeparator` tags accordingly.
 
 ## Custom Parser Funcs
 

--- a/env.go
+++ b/env.go
@@ -518,11 +518,16 @@ func handleMap(field reflect.Value, value string, sf reflect.StructField, funcMa
 		separator = ","
 	}
 
+	keyValSeparator := sf.Tag.Get("envKeyValSeparator")
+	if keyValSeparator == "" {
+		keyValSeparator = ":"
+	}
+
 	result := reflect.MakeMap(sf.Type)
 	for _, part := range strings.Split(value, separator) {
-		pairs := strings.Split(part, ":")
+		pairs := strings.Split(part, keyValSeparator)
 		if len(pairs) != 2 {
-			return newParseError(sf, fmt.Errorf(`%q should be in "key:value" format`, part))
+			return newParseError(sf, fmt.Errorf(`%q should be in "key%svalue" format`, part, keyValSeparator))
 		}
 
 		key, err := keyParserFunc(pairs[0])

--- a/env_test.go
+++ b/env_test.go
@@ -403,7 +403,7 @@ func TestParsesEnv(t *testing.T) {
 
 func TestParsesEnv_Map(t *testing.T) {
 	type config struct {
-		MapStringString map[string]string `env:"MAP_STRING_STRING" envSeparator:","`
+		MapStringString map[string]string `env:"MAP_STRING_STRING" envSeparator:","  envKeyValSeparator:"|"`
 		MapStringInt64  map[string]int64  `env:"MAP_STRING_INT64"`
 		MapStringBool   map[string]bool   `env:"MAP_STRING_BOOL" envSeparator:";"`
 	}
@@ -412,7 +412,7 @@ func TestParsesEnv_Map(t *testing.T) {
 		"k1": "v1",
 		"k2": "v2",
 	}
-	t.Setenv("MAP_STRING_STRING", "k1:v1,k2:v2")
+	t.Setenv("MAP_STRING_STRING", "k1|v1,k2|v2")
 
 	msi := map[string]int64{
 		"k1": 1,

--- a/env_test.go
+++ b/env_test.go
@@ -403,16 +403,17 @@ func TestParsesEnv(t *testing.T) {
 
 func TestParsesEnv_Map(t *testing.T) {
 	type config struct {
-		MapStringString map[string]string `env:"MAP_STRING_STRING" envSeparator:","  envKeyValSeparator:"|"`
-		MapStringInt64  map[string]int64  `env:"MAP_STRING_INT64"`
-		MapStringBool   map[string]bool   `env:"MAP_STRING_BOOL" envSeparator:";"`
+		MapStringString                map[string]string `env:"MAP_STRING_STRING" envSeparator:","`
+		MapStringInt64                 map[string]int64  `env:"MAP_STRING_INT64"`
+		MapStringBool                  map[string]bool   `env:"MAP_STRING_BOOL" envSeparator:";"`
+		CustomSeparatorMapStringString map[string]string `env:"CUSTOM_SEPARATOR_MAP_STRING_STRING" envSeparator:"," envKeyValSeparator:"|"`
 	}
 
 	mss := map[string]string{
 		"k1": "v1",
 		"k2": "v2",
 	}
-	t.Setenv("MAP_STRING_STRING", "k1|v1,k2|v2")
+	t.Setenv("MAP_STRING_STRING", "k1:v1,k2:v2")
 
 	msi := map[string]int64{
 		"k1": 1,
@@ -426,12 +427,19 @@ func TestParsesEnv_Map(t *testing.T) {
 	}
 	t.Setenv("MAP_STRING_BOOL", "k1:true;k2:false")
 
+	withCustomSeparator := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	t.Setenv("CUSTOM_SEPARATOR_MAP_STRING_STRING", "k1|v1,k2|v2")
+
 	var cfg config
 	isNoErr(t, Parse(&cfg))
 
 	isEqual(t, mss, cfg.MapStringString)
 	isEqual(t, msi, cfg.MapStringInt64)
 	isEqual(t, msb, cfg.MapStringBool)
+	isEqual(t, withCustomSeparator, cfg.CustomSeparatorMapStringString)
 }
 
 func TestParsesEnvInvalidMap(t *testing.T) {


### PR DESCRIPTION
We have use cases, when we would use ":" as a map value. For example,in the case of "default:http://example.com/," this functionality is currently unavailable due to the ":" character being reserved as a separator between keys and values. This pull request solves the problem.

If you have any suggestions for a more suitable name instead of `envKeyValSeparator`, please feel free to share