### PR TITLE
enhancement: Expand with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ import (
 )
 
 type config struct {
-	Host            string `env:"HOST" envDefault:"localhost"`
-	Port            int    `env:"PORT" envDefault:"3000"`
-	Address			string `env:"ADDRESS,expand" envDefault:"$HOST:${PORT}"`
+	Host     string `env:"HOST" envDefault:"localhost"`
+	Port     int    `env:"PORT" envDefault:"3000"`
+	Address  string `env:"ADDRESS,expand" envDefault:"$HOST:${PORT}"`
 }
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -180,7 +180,34 @@ type config struct {
 }
 ```
 
-This also works with `envDefault`.
+This also works with `envDefault`:
+```go
+import (
+	"fmt"
+	"github.com/caarlos0/env/v9"
+)
+
+type config struct {
+	Host            string `env:"HOST" envDefault:"localhost"`
+	Port            int    `env:"PORT" envDefault:"3000"`
+	Address			string `env:"ADDRESS,expand" envDefault:"$HOST:${PORT}"`
+}
+
+func main() {
+	cfg := config{}
+	if err := env.Parse(&cfg); err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+	fmt.Printf("%+v\n", cfg)
+}
+```
+
+results in this:
+
+```sh
+$ PORT=8080 go run main.go
+{Host:localhost Port:8080 Address:localhost:8080}
+```
 
 ## Not Empty fields
 

--- a/env.go
+++ b/env.go
@@ -392,7 +392,7 @@ func getFromFile(filename string) (value string, err error) {
 	return string(b), err
 }
 
-func getOr(key, defaultValue string, defExists bool, envs map[string]string) (string, bool, bool) {
+func getOr(key, defaultValue string, defExists bool, envs map[string]string) (val string, exists bool, isDefault bool) {
 	value, exists := envs[key]
 	switch {
 	case (!exists || key == "") && defExists:

--- a/env.go
+++ b/env.go
@@ -167,10 +167,6 @@ func customOptions(opt Options) Options {
 }
 
 func optionsWithEnvPrefix(field reflect.StructField, opts Options) Options {
-	rawEnvVars := opts.rawEnvVars
-	if rawEnvVars == nil {
-		rawEnvVars = make(map[string]string)
-	}
 	return Options{
 		Environment:           opts.Environment,
 		TagName:               opts.TagName,
@@ -179,7 +175,7 @@ func optionsWithEnvPrefix(field reflect.StructField, opts Options) Options {
 		Prefix:                opts.Prefix + field.Tag.Get("envPrefix"),
 		UseFieldNameByDefault: opts.UseFieldNameByDefault,
 		FuncMap:               opts.FuncMap,
-		rawEnvVars:            rawEnvVars,
+		rawEnvVars:            opts.rawEnvVars,
 	}
 }
 


### PR DESCRIPTION
resolves #279 (and resolves #250 (?))

### Approach:

To capture the default values when expanding envs, we need to somehow have access to the previously resolved variables.

So, the `get()` function needs an auxiliar data structure (`map[string]string`) that will keep track of the resolved raw strings. In that way, we can take advange of `os.Expand(s string, mapping func(string) string)` to provide our own mapping function that returns the resolved string value for a given key.

To avoid passing this auxiliar data structure as a parameter down the function calls, I added it as an unexported field of the Options struct, let's say, using `opts` as if it were a `ctx`.

I'm not really sure if it's the best way of doing this, any suggestions will be more than appreciated!

edit: typo