### PR TITLE
Add envDepends tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ type config struct {
 }
 ```
 
+## Depending environment variables
+
+You may define depending environment variables which should be exist 
+and the value is set (in your `environment` or as `envDefault`) for a certain field.
+It works only if the value of the field is set. 
+
+Example:
+
+```go
+type config struct {
+	Production bool   `env:"PRODUCTION"`
+	Name       string `env:"NAME"`
+	SecretKey  string `env:"SECRET_KEY" envDepends:"PRODUCTION,NAME"`
+}
+```
+
 ## Unset environment variable after reading it
 
 The `env` tag option `unset` (e.g., `env:"tagKey,unset"`) can be added

--- a/env.go
+++ b/env.go
@@ -241,7 +241,12 @@ func doParse(ref reflect.Value, processField processFieldFn, opts Options) error
 		refTypeField := refType.Field(i)
 		params, err := parseFieldParams(refTypeField, opts)
 		if err != nil {
-			return err
+			if val, ok := err.(AggregateError); ok {
+				agrErr.Errors = append(agrErr.Errors, val.Errors...)
+			} else {
+				agrErr.Errors = append(agrErr.Errors, err)
+			}
+			continue
 		}
 		structFields[refTypeField.Name] = params
 	}

--- a/env.go
+++ b/env.go
@@ -394,7 +394,7 @@ func get(fieldParams FieldParams, opts Options) (val string, err error) {
 		defer os.Unsetenv(fieldParams.Key)
 	}
 
-	if fieldParams.HasDependsKeys {
+	if fieldParams.HasDependsKeys && val != "" {
 		dependencies := checkDependencies(fieldParams.DependsKeys, opts.Environment)
 		if len(dependencies) > 0 {
 			return "", newDependsEnvVarError(fieldParams.Key, dependencies)

--- a/env.go
+++ b/env.go
@@ -435,8 +435,8 @@ func checkDependencies(dependsKeys []string, envs map[string]string) (emptyKeys 
 				}
 				if !field.HasDefaultValue {
 					emptyKeys = append(emptyKeys, dependsKey)
-					break
 				}
+				break
 			}
 		}
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -1371,9 +1371,7 @@ func TestExampleParse(t *testing.T) {
 	}
 	t.Setenv("HOME", "/tmp/fakehome")
 	var cfg config
-	if err := Parse(&cfg); err != nil {
-		fmt.Println("failed:", err)
-	}
+	isNoErr(t, Parse(&cfg))
 	fmt.Printf("%+v", cfg)
 	// Output:  {Home:/tmp/fakehome Port:3000 IsProduction:false TempFolder:/tmp/fakehome/.tmp StringInts:map[k1:1 k2:2] Inner:{Foo:foobar}}
 }
@@ -1387,11 +1385,22 @@ func TestExampleParse_onDepends(t *testing.T) {
 	t.Setenv("HOME", "/tmp/fakehome")
 	t.Setenv("PRODUCTION", "true")
 	var cfg config
-	if err := Parse(&cfg); err != nil {
-		fmt.Println("failed:", err)
-	}
+	isNoErr(t, Parse(&cfg))
 	fmt.Printf("%+v", cfg)
 	// Output:  {Home:/tmp/fakehome Port:3000 IsProduction:true}
+}
+
+func TestExampleParse_noValue_onDepends(t *testing.T) {
+	type config struct {
+		Home         string `env:"HOME,required"`
+		Port         int    `env:"PORT" envDefault:"3000"`
+		IsProduction bool   `env:"PRODUCTION" envDepends:"HOME,PORT"`
+	}
+	t.Setenv("HOME", "/tmp/fakehome")
+	var cfg config
+	isNoErr(t, Parse(&cfg))
+	fmt.Printf("%+v", cfg)
+	// Output:  {Home:/tmp/fakehome Port:3000 IsProduction:false}
 }
 
 func TestExampleParse_onSet(t *testing.T) {
@@ -1404,13 +1413,13 @@ func TestExampleParse_onSet(t *testing.T) {
 	}
 	t.Setenv("HOME", "/tmp/fakehome")
 	var cfg config
-	if err := ParseWithOptions(&cfg, Options{
-		OnSet: func(tag string, value interface{}, isDefault bool) {
-			fmt.Printf("Set %s to %v (default? %v)\n", tag, value, isDefault)
-		},
-	}); err != nil {
-		fmt.Println("failed:", err)
-	}
+	isNoErr(t,
+		ParseWithOptions(&cfg, Options{
+			OnSet: func(tag string, value interface{}, isDefault bool) {
+				fmt.Printf("Set %s to %v (default? %v)\n", tag, value, isDefault)
+			},
+		}),
+	)
 	fmt.Printf("%+v", cfg)
 	// Output: Set HOME to /tmp/fakehome (default? false)
 	// Set PORT to 3000 (default? true)
@@ -1430,9 +1439,7 @@ func TestExampleParse_defaults(t *testing.T) {
 		A: "A",
 		B: "B",
 	}
-	if err := Parse(&cfg); err != nil {
-		fmt.Println("failed:", err)
-	}
+	isNoErr(t, Parse(&cfg))
 	fmt.Printf("%+v", cfg)
 	// Output: {A:foo B:B}
 }

--- a/env_test.go
+++ b/env_test.go
@@ -1357,7 +1357,7 @@ func TestParseDepsNotSet(t *testing.T) {
 	isTrue(t, errors.Is(err, DependsEnvVarError{}))
 }
 
-func ExampleParse() {
+func TestExampleParse(t *testing.T) {
 	type inner struct {
 		Foo string `env:"FOO" envDefault:"foobar"`
 	}
@@ -1369,7 +1369,7 @@ func ExampleParse() {
 		StringInts   map[string]int `env:"MAP_STRING_INT" envDefault:"k1:1,k2:2"`
 		Inner        inner
 	}
-	os.Setenv("HOME", "/tmp/fakehome")
+	t.Setenv("HOME", "/tmp/fakehome")
 	var cfg config
 	if err := Parse(&cfg); err != nil {
 		fmt.Println("failed:", err)
@@ -1378,14 +1378,14 @@ func ExampleParse() {
 	// Output:  {Home:/tmp/fakehome Port:3000 IsProduction:false TempFolder:/tmp/fakehome/.tmp StringInts:map[k1:1 k2:2] Inner:{Foo:foobar}}
 }
 
-func ExampleParse_onDepends() {
+func TestExampleParse_onDepends(t *testing.T) {
 	type config struct {
 		Home         string `env:"HOME,required"`
 		Port         int    `env:"PORT" envDefault:"3000"`
 		IsProduction bool   `env:"PRODUCTION" envDepends:"HOME,PORT"`
 	}
-	os.Setenv("HOME", "/tmp/fakehome")
-	os.Setenv("PRODUCTION", "true")
+	t.Setenv("HOME", "/tmp/fakehome")
+	t.Setenv("PRODUCTION", "true")
 	var cfg config
 	if err := Parse(&cfg); err != nil {
 		fmt.Println("failed:", err)
@@ -1394,7 +1394,7 @@ func ExampleParse_onDepends() {
 	// Output:  {Home:/tmp/fakehome Port:3000 IsProduction:true}
 }
 
-func ExampleParse_onSet() {
+func TestExampleParse_onSet(t *testing.T) {
 	type config struct {
 		Home         string `env:"HOME,required"`
 		Port         int    `env:"PORT" envDefault:"3000"`
@@ -1402,7 +1402,7 @@ func ExampleParse_onSet() {
 		NoEnvTag     bool
 		Inner        struct{} `envPrefix:"INNER_"`
 	}
-	os.Setenv("HOME", "/tmp/fakehome")
+	t.Setenv("HOME", "/tmp/fakehome")
 	var cfg config
 	if err := ParseWithOptions(&cfg, Options{
 		OnSet: func(tag string, value interface{}, isDefault bool) {
@@ -1418,7 +1418,7 @@ func ExampleParse_onSet() {
 	// {Home:/tmp/fakehome Port:3000 IsProduction:false NoEnvTag:false Inner:{}}
 }
 
-func ExampleParse_defaults() {
+func TestExampleParse_defaults(t *testing.T) {
 	type config struct {
 		A string `env:"FOO" envDefault:"foo"`
 		B string `env:"FOO"`
@@ -1486,7 +1486,7 @@ func TestPrecedenceUnmarshalText(t *testing.T) {
 	isEqual(t, []LogLevel{DebugLevel, InfoLevel}, cfg.LogLevels)
 }
 
-func ExampleParseWithOptions() {
+func TestExampleParseWithOptions(t *testing.T) {
 	type thing struct {
 		desc string
 	}

--- a/error.go
+++ b/error.go
@@ -14,6 +14,7 @@ import (
 // NoSupportedTagOptionError
 // EnvVarIsNotSetError
 // EmptyEnvVarError
+// DependsEnvVarError
 // LoadFileContentError
 // ParseValueError
 type AggregateError struct {
@@ -131,8 +132,8 @@ func (e EmptyEnvVarError) Error() string {
 	return fmt.Sprintf("environment variable %q should not be empty", e.Key)
 }
 
-// This error occurs when the variable have dependenices
-// Read about dependency fields: https://github.com/caarlos0/env#dependency-fields
+// This error occurs when the variable is set and have dependenices
+// Read about dependency fields: https://github.com/caarlos0/env#depending-environment-variables
 type DependsEnvVarError struct {
 	Key         string
 	DependsKeys []string

--- a/error.go
+++ b/error.go
@@ -131,6 +131,21 @@ func (e EmptyEnvVarError) Error() string {
 	return fmt.Sprintf("environment variable %q should not be empty", e.Key)
 }
 
+// This error occurs when the variable have dependenices
+// Read about dependency fields: https://github.com/caarlos0/env#dependency-fields
+type DependsEnvVarError struct {
+	Key         string
+	DependsKeys []string
+}
+
+func newDependsEnvVarError(key string, dependsKeys []string) error {
+	return DependsEnvVarError{key, dependsKeys}
+}
+
+func (e DependsEnvVarError) Error() string {
+	return fmt.Sprintf("environment variable %q has dependencies: %v", e.Key, strings.Join(e.DependsKeys, ", "))
+}
+
 // This error occurs when it's impossible to load the value from the file
 // Read about From file feature: https://github.com/caarlos0/env#from-file
 type LoadFileContentError struct {


### PR DESCRIPTION
Hello,

In my case I want to use the "notEmpty" tag for a field like:

```
type foobar struct{
  IsEnabled bool `env:"IS_ENABLED" envDefault:"true"`
  Name string `env:"NAME,notEmpty"`
}
```

but the "NAME" should depends on if "IS_ENABLED" is set. My idea is to add a new tag envDepends like the same syntax as envDefault. In the envDepends tag you can define the needed env field(s).

The new struct will be shown like:

```
type foobar struct{
  IsEnabled bool `env:"IS_ENABLED envDefault:"true"`
  Name string `env:"NAME"  envDepends:"IS_ENABLED, ...."`
}
```

The envDepends combine "required" and "notEmpty" tag to ensure that all needed fields have values (by environment or default tag) if you use the field "IS_ENABLED" in my example above.

What do you think about it? :blush: