### PR TITLE
#234 - fix: add logic to handle nil pointer structs

### DIFF
--- a/env.go
+++ b/env.go
@@ -300,6 +300,15 @@ func doParseField(refField reflect.Value, refTypeField reflect.StructField, proc
 		return err
 	}
 
+	if isStructPtr(refField) && refField.IsNil() {
+		refField.Set(reflect.New(refField.Type().Elem()))
+		refField = refField.Elem()
+	}
+
+	if _, ok := opts.FuncMap[refField.Type()]; ok {
+		return nil
+	}
+
 	if reflect.Struct == refField.Kind() {
 		return doParse(refField, processField, optionsWithEnvPrefix(refTypeField, opts))
 	}
@@ -643,4 +652,8 @@ func parseTextUnmarshalers(field reflect.Value, data []string, sf reflect.Struct
 // can use as Options.Environment field
 func ToMap(env []string) map[string]string {
 	return toMap(env)
+}
+
+func isStructPtr(v reflect.Value) bool {
+	return reflect.Ptr == v.Kind() && v.Type().Elem().Kind() == reflect.Struct
 }

--- a/env_test.go
+++ b/env_test.go
@@ -595,6 +595,15 @@ func TestParsesEnvInner(t *testing.T) {
 	isEqual(t, uint(8), cfg.InnerStruct.Number)
 }
 
+func TestParsesEnvInner_WhenInnerStructPointerIsNil(t *testing.T) {
+	t.Setenv("innervar", "someinnervalue")
+	t.Setenv("innernum", "8")
+	cfg := ParentStruct{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "someinnervalue", cfg.InnerStruct.Inner)
+	isEqual(t, uint(8), cfg.InnerStruct.Number)
+}
+
 func TestParsesEnvInnerFails(t *testing.T) {
 	type config struct {
 		Foo struct {


### PR DESCRIPTION
This commit fixes the nil pointer structs. 
If a struct pointer field is **nil**, it will be initialised first & then used for further processing.