### PR TITLE
Support other names for envDefault

### DIFF
--- a/env.go
+++ b/env.go
@@ -122,6 +122,9 @@ type Options struct {
 	// TagName specifies another tag name to use rather than the default 'env'.
 	TagName string
 
+	// DefaultTagName specifies another default tag name to use rather than the default 'envDefault'.
+	DefaultTagName string
+
 	// RequiredIfNoDef automatically sets all fields as required if they do not
 	// declare 'envDefault'.
 	RequiredIfNoDef bool
@@ -156,10 +159,11 @@ func (opts *Options) getRawEnv(s string) string {
 
 func defaultOptions() Options {
 	return Options{
-		TagName:     "env",
-		Environment: toMap(os.Environ()),
-		FuncMap:     defaultTypeParsers(),
-		rawEnvVars:  make(map[string]string),
+		TagName:        "env",
+		DefaultTagName: "envDefault",
+		Environment:    toMap(os.Environ()),
+		FuncMap:        defaultTypeParsers(),
+		rawEnvVars:     make(map[string]string),
 	}
 }
 
@@ -167,6 +171,9 @@ func customOptions(opt Options) Options {
 	defOpts := defaultOptions()
 	if opt.TagName == "" {
 		opt.TagName = defOpts.TagName
+	}
+	if opt.DefaultTagName == "" {
+		opt.DefaultTagName = defOpts.DefaultTagName
 	}
 	if opt.Environment == nil {
 		opt.Environment = defOpts.Environment
@@ -189,6 +196,7 @@ func optionsWithSliceEnvPrefix(opts Options, index int) Options {
 	return Options{
 		Environment:           opts.Environment,
 		TagName:               opts.TagName,
+		DefaultTagName:        opts.DefaultTagName,
 		RequiredIfNoDef:       opts.RequiredIfNoDef,
 		OnSet:                 opts.OnSet,
 		Prefix:                fmt.Sprintf("%s%d_", opts.Prefix, index),
@@ -202,6 +210,7 @@ func optionsWithEnvPrefix(field reflect.StructField, opts Options) Options {
 	return Options{
 		Environment:           opts.Environment,
 		TagName:               opts.TagName,
+		DefaultTagName:        opts.DefaultTagName,
 		RequiredIfNoDef:       opts.RequiredIfNoDef,
 		OnSet:                 opts.OnSet,
 		Prefix:                opts.Prefix + field.Tag.Get("envPrefix"),
@@ -500,7 +509,7 @@ func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, err
 		ownKey = toEnvName(field.Name)
 	}
 
-	defaultValue, hasDefaultValue := field.Tag.Lookup("envDefault")
+	defaultValue, hasDefaultValue := field.Tag.Lookup(opts.DefaultTagName)
 
 	result := FieldParams{
 		OwnKey:          ownKey,

--- a/env.go
+++ b/env.go
@@ -122,8 +122,8 @@ type Options struct {
 	// TagName specifies another tag name to use rather than the default 'env'.
 	TagName string
 
-	// DefaultTagName specifies another default tag name to use rather than the default 'envDefault'.
-	DefaultTagName string
+	// DefaultValueTagName specifies another default tag name to use rather than the default 'envDefault'.
+	DefaultValueTagName string
 
 	// RequiredIfNoDef automatically sets all fields as required if they do not
 	// declare 'envDefault'.
@@ -159,11 +159,11 @@ func (opts *Options) getRawEnv(s string) string {
 
 func defaultOptions() Options {
 	return Options{
-		TagName:        "env",
-		DefaultTagName: "envDefault",
-		Environment:    toMap(os.Environ()),
-		FuncMap:        defaultTypeParsers(),
-		rawEnvVars:     make(map[string]string),
+		TagName:             "env",
+		DefaultValueTagName: "envDefault",
+		Environment:         toMap(os.Environ()),
+		FuncMap:             defaultTypeParsers(),
+		rawEnvVars:          make(map[string]string),
 	}
 }
 
@@ -172,8 +172,8 @@ func customOptions(opt Options) Options {
 	if opt.TagName == "" {
 		opt.TagName = defOpts.TagName
 	}
-	if opt.DefaultTagName == "" {
-		opt.DefaultTagName = defOpts.DefaultTagName
+	if opt.DefaultValueTagName == "" {
+		opt.DefaultValueTagName = defOpts.DefaultValueTagName
 	}
 	if opt.Environment == nil {
 		opt.Environment = defOpts.Environment
@@ -196,7 +196,7 @@ func optionsWithSliceEnvPrefix(opts Options, index int) Options {
 	return Options{
 		Environment:           opts.Environment,
 		TagName:               opts.TagName,
-		DefaultTagName:        opts.DefaultTagName,
+		DefaultValueTagName:   opts.DefaultValueTagName,
 		RequiredIfNoDef:       opts.RequiredIfNoDef,
 		OnSet:                 opts.OnSet,
 		Prefix:                fmt.Sprintf("%s%d_", opts.Prefix, index),
@@ -210,7 +210,7 @@ func optionsWithEnvPrefix(field reflect.StructField, opts Options) Options {
 	return Options{
 		Environment:           opts.Environment,
 		TagName:               opts.TagName,
-		DefaultTagName:        opts.DefaultTagName,
+		DefaultValueTagName:   opts.DefaultValueTagName,
 		RequiredIfNoDef:       opts.RequiredIfNoDef,
 		OnSet:                 opts.OnSet,
 		Prefix:                opts.Prefix + field.Tag.Get("envPrefix"),
@@ -509,7 +509,7 @@ func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, err
 		ownKey = toEnvName(field.Name)
 	}
 
-	defaultValue, hasDefaultValue := field.Tag.Lookup(opts.DefaultTagName)
+	defaultValue, hasDefaultValue := field.Tag.Lookup(opts.DefaultValueTagName)
 
 	result := FieldParams{
 		OwnKey:          ownKey,

--- a/env_test.go
+++ b/env_test.go
@@ -2145,3 +2145,16 @@ func TestIssue320(t *testing.T) {
 	isEqual(t, cfg.Bar, nil)
 	isEqual(t, cfg.Baz, nil)
 }
+
+func TestParseWithOptionsRenamedDefault(t *testing.T) {
+	type config struct {
+		Str string `env:"STR" envDefault:"foo" myDefault:"bar"`
+	}
+
+	cfg := &config{}
+	isNoErr(t, ParseWithOptions(cfg, Options{DefaultTagName: "myDefault"}))
+	isEqual(t, "bar", cfg.Str)
+
+	isNoErr(t, Parse(cfg))
+	isEqual(t, "foo", cfg.Str)
+}

--- a/env_test.go
+++ b/env_test.go
@@ -2152,7 +2152,7 @@ func TestParseWithOptionsRenamedDefault(t *testing.T) {
 	}
 
 	cfg := &config{}
-	isNoErr(t, ParseWithOptions(cfg, Options{DefaultTagName: "myDefault"}))
+	isNoErr(t, ParseWithOptions(cfg, Options{DefaultValueTagName: "myDefault"}))
 	isEqual(t, "bar", cfg.Str)
 
 	isNoErr(t, Parse(cfg))


### PR DESCRIPTION
We can change the "env" to some other tag name using opt.TagName. I think that it will be more consistent to have an opt.DefaultTagName to change the tag for "envDefault".

That could help switching from other env libraries.