### PR TITLE
Options to set defaults for zero values only

### DIFF
--- a/env.go
+++ b/env.go
@@ -162,6 +162,15 @@ type Options struct {
 	// variable names conventions.
 	UseFieldNameByDefault bool
 
+	// SetDefaultsForZeroValuesOnly defines whether to set defaults for zero values
+	// If the `env` variable for the value is not set
+	// and `envDefault` is set
+	// and the value is not a zero value for the the type
+	// and SetDefaultsForZeroValuesOnly=true
+	// the value from `envDefault` will be ignored
+	// Usefull for mixing default values from `envDefault` and struct initialization
+	SetDefaultsForZeroValuesOnly bool
+
 	// Custom parse functions for different types.
 	FuncMap map[reflect.Type]ParserFunc
 
@@ -219,31 +228,33 @@ func customOptions(opt Options) Options {
 
 func optionsWithSliceEnvPrefix(opts Options, index int) Options {
 	return Options{
-		Environment:           opts.Environment,
-		TagName:               opts.TagName,
-		PrefixTagName:         opts.PrefixTagName,
-		DefaultValueTagName:   opts.DefaultValueTagName,
-		RequiredIfNoDef:       opts.RequiredIfNoDef,
-		OnSet:                 opts.OnSet,
-		Prefix:                fmt.Sprintf("%s%d_", opts.Prefix, index),
-		UseFieldNameByDefault: opts.UseFieldNameByDefault,
-		FuncMap:               opts.FuncMap,
-		rawEnvVars:            opts.rawEnvVars,
+		Environment:                  opts.Environment,
+		TagName:                      opts.TagName,
+		PrefixTagName:                opts.PrefixTagName,
+		DefaultValueTagName:          opts.DefaultValueTagName,
+		RequiredIfNoDef:              opts.RequiredIfNoDef,
+		OnSet:                        opts.OnSet,
+		Prefix:                       fmt.Sprintf("%s%d_", opts.Prefix, index),
+		UseFieldNameByDefault:        opts.UseFieldNameByDefault,
+		SetDefaultsForZeroValuesOnly: opts.SetDefaultsForZeroValuesOnly,
+		FuncMap:                      opts.FuncMap,
+		rawEnvVars:                   opts.rawEnvVars,
 	}
 }
 
 func optionsWithEnvPrefix(field reflect.StructField, opts Options) Options {
 	return Options{
-		Environment:           opts.Environment,
-		TagName:               opts.TagName,
-		PrefixTagName:         opts.PrefixTagName,
-		DefaultValueTagName:   opts.DefaultValueTagName,
-		RequiredIfNoDef:       opts.RequiredIfNoDef,
-		OnSet:                 opts.OnSet,
-		Prefix:                opts.Prefix + field.Tag.Get(opts.PrefixTagName),
-		UseFieldNameByDefault: opts.UseFieldNameByDefault,
-		FuncMap:               opts.FuncMap,
-		rawEnvVars:            opts.rawEnvVars,
+		Environment:                  opts.Environment,
+		TagName:                      opts.TagName,
+		PrefixTagName:                opts.PrefixTagName,
+		DefaultValueTagName:          opts.DefaultValueTagName,
+		RequiredIfNoDef:              opts.RequiredIfNoDef,
+		OnSet:                        opts.OnSet,
+		Prefix:                       opts.Prefix + field.Tag.Get(opts.PrefixTagName),
+		UseFieldNameByDefault:        opts.UseFieldNameByDefault,
+		SetDefaultsForZeroValuesOnly: opts.SetDefaultsForZeroValuesOnly,
+		FuncMap:                      opts.FuncMap,
+		rawEnvVars:                   opts.rawEnvVars,
 	}
 }
 
@@ -497,7 +508,7 @@ func setField(refField reflect.Value, refTypeField reflect.StructField, opts Opt
 		return err
 	}
 
-	if value != "" {
+	if value != "" && (!opts.SetDefaultsForZeroValuesOnly || refField.IsZero()) {
 		return set(refField, refTypeField, value, opts.FuncMap)
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -2192,6 +2192,63 @@ func TestParseWithOptionsRenamedDefault(t *testing.T) {
 	isEqual(t, "foo", cfg.Str)
 }
 
+func TestSetDefaultsForZeroValuesOnly(t *testing.T) {
+	type config struct {
+		Str string  `env:"STR" envDefault:"foo"`
+		Int int     `env:"INT" envDefault:"42"`
+		Url url.URL `env:"URL" envDefault:"https://github.com/caarlos0"`
+	}
+	defUrl, err := url.Parse("https://github.com/caarlos0")
+	isNoErr(t, err)
+
+	u, err := url.Parse("https://localhost/foo")
+	isNoErr(t, err)
+
+	for _, tc := range []struct {
+		Name     string
+		Options  Options
+		Expected config
+	}{
+		{
+			Name:    "true",
+			Options: Options{SetDefaultsForZeroValuesOnly: true},
+			Expected: config{
+				Str: "isSet",
+				Int: 1,
+				Url: *u,
+			},
+		},
+		{
+			Name:    "false",
+			Options: Options{SetDefaultsForZeroValuesOnly: false},
+			Expected: config{
+				Str: "foo",
+				Int: 42,
+				Url: *defUrl,
+			},
+		},
+		{
+			Name:    "default",
+			Options: Options{},
+			Expected: config{
+				Str: "foo",
+				Int: 42,
+				Url: *defUrl,
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			cfg := &config{
+				Str: "isSet",
+				Int: 1,
+				Url: *u,
+			}
+			isNoErr(t, ParseWithOptions(cfg, tc.Options))
+			isEqual(t, tc.Expected, *cfg)
+		})
+	}
+}
+
 func TestParseWithOptionsRenamedPrefix(t *testing.T) {
 	type Config struct {
 		Str string `env:"STR"`

--- a/example_test.go
+++ b/example_test.go
@@ -456,3 +456,27 @@ func ExampleParse_errorHandling() {
 	// daisy
 	// {Username:admin Password:}
 }
+
+// You can avoid setting defaults for non zero values
+// This could be useful for loading data from config file first
+// and then filling the rest from env
+func Example_setDefaultsForZeroValuesOnly() {
+	type Config struct {
+		Username string `env:"USERNAME" envDefault:"admin"`
+		Password string `env:"PASSWORD" envDefault:"qwerty"`
+	}
+
+	cfg := Config{
+		Username: "root",
+	}
+
+	if err := ParseWithOptions(&cfg, Options{
+		Environment:                  map[string]string{},
+		SetDefaultsForZeroValuesOnly: true,
+	}); err != nil {
+		fmt.Println(err)
+	}
+
+	fmt.Printf("%+v", cfg)
+	// Output: {Username:root Password:qwerty}
+}


### PR DESCRIPTION
I've encountered scenarious of loading config from file and then applying env vars.
Would be nice to ignore defaults for thouse values already set.