### PR TITLE
Support custom tag name for envPrefix

### DIFF
--- a/env.go
+++ b/env.go
@@ -135,6 +135,9 @@ type Options struct {
 	// TagName specifies another tag name to use rather than the default 'env'.
 	TagName string
 
+	// PrefixTagName specifies another prefix tag name to use rather than the default 'envPrefix'.
+	PrefixTagName string
+
 	// DefaultValueTagName specifies another default tag name to use rather than the default 'envDefault'.
 	DefaultValueTagName string
 
@@ -173,6 +176,7 @@ func (opts *Options) getRawEnv(s string) string {
 func defaultOptions() Options {
 	return Options{
 		TagName:             "env",
+		PrefixTagName:       "envPrefix",
 		DefaultValueTagName: "envDefault",
 		Environment:         toMap(os.Environ()),
 		FuncMap:             defaultTypeParsers(),
@@ -184,6 +188,9 @@ func customOptions(opt Options) Options {
 	defOpts := defaultOptions()
 	if opt.TagName == "" {
 		opt.TagName = defOpts.TagName
+	}
+	if opt.PrefixTagName == "" {
+		opt.PrefixTagName = defOpts.PrefixTagName
 	}
 	if opt.DefaultValueTagName == "" {
 		opt.DefaultValueTagName = defOpts.DefaultValueTagName
@@ -209,6 +216,7 @@ func optionsWithSliceEnvPrefix(opts Options, index int) Options {
 	return Options{
 		Environment:           opts.Environment,
 		TagName:               opts.TagName,
+		PrefixTagName:         opts.PrefixTagName,
 		DefaultValueTagName:   opts.DefaultValueTagName,
 		RequiredIfNoDef:       opts.RequiredIfNoDef,
 		OnSet:                 opts.OnSet,
@@ -223,10 +231,11 @@ func optionsWithEnvPrefix(field reflect.StructField, opts Options) Options {
 	return Options{
 		Environment:           opts.Environment,
 		TagName:               opts.TagName,
+		PrefixTagName:         opts.PrefixTagName,
 		DefaultValueTagName:   opts.DefaultValueTagName,
 		RequiredIfNoDef:       opts.RequiredIfNoDef,
 		OnSet:                 opts.OnSet,
-		Prefix:                opts.Prefix + field.Tag.Get("envPrefix"),
+		Prefix:                opts.Prefix + field.Tag.Get(opts.PrefixTagName),
 		UseFieldNameByDefault: opts.UseFieldNameByDefault,
 		FuncMap:               opts.FuncMap,
 		rawEnvVars:            opts.rawEnvVars,

--- a/env_test.go
+++ b/env_test.go
@@ -2190,3 +2190,26 @@ func TestParseWithOptionsRenamedDefault(t *testing.T) {
 	isNoErr(t, Parse(cfg))
 	isEqual(t, "foo", cfg.Str)
 }
+
+func TestParseWithOptionsRenamedPrefix(t *testing.T) {
+	type Config struct {
+		Str string `env:"STR"`
+	}
+	type ComplexConfig struct {
+		Foo Config `envPrefix:"FOO_" myPrefix:"BAR_"`
+	}
+
+	t.Setenv("FOO_STR", "101")
+	t.Setenv("BAR_STR", "202")
+	t.Setenv("APP_BAR_STR", "303")
+
+	cfg := &ComplexConfig{}
+	isNoErr(t, ParseWithOptions(cfg, Options{PrefixTagName: "myPrefix"}))
+	isEqual(t, "202", cfg.Foo.Str)
+
+	isNoErr(t, ParseWithOptions(cfg, Options{PrefixTagName: "myPrefix", Prefix: "APP_"}))
+	isEqual(t, "303", cfg.Foo.Str)
+
+	isNoErr(t, Parse(cfg))
+	isEqual(t, "101", cfg.Foo.Str)
+}


### PR DESCRIPTION
We can change "env" or "envDefault" to some other tag name. I think it would be more consistent to have opt.PrefixTagName to change the tag to "envPrefix".

This might help when migrating from other environment libraries.