### PR TITLE
add option to ignore prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Here are all the options available for the `env` tag:
 
 - `,expand`: expands environment variables, e.g. `FOO_${BAR}`
 - `,file`: instructs that the content of the variable is a path to a file that should be read
+- `,ignorePrefix`: ignore the prefix when parsing the environment variable name
 - `,init`: initialize nil pointers
 - `,notEmpty`: make the field errors if the environment variable is empty
 - `,required`: make the field errors if the environment variable is not set

--- a/env.go
+++ b/env.go
@@ -514,6 +514,7 @@ type FieldParams struct {
 	NotEmpty        bool
 	Expand          bool
 	Init            bool
+	IgnorePrefix    bool
 }
 
 func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, error) {
@@ -548,9 +549,15 @@ func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, err
 			result.Expand = true
 		case "init":
 			result.Init = true
+		case "ignorePrefix":
+			result.IgnorePrefix = true
 		default:
 			return FieldParams{}, newNoSupportedTagOptionError(tag)
 		}
+	}
+
+	if result.IgnorePrefix {
+		result.Key = ownKey
 	}
 
 	return result, nil

--- a/env_test.go
+++ b/env_test.go
@@ -1693,6 +1693,33 @@ func TestComplePrefix(t *testing.T) {
 	isEqual(t, "blahhh", cfg.Blah)
 }
 
+func TestIgnorePrefix(t *testing.T) {
+	type Inner struct {
+		GlobalEnv    string `env:"GLOBAL_ENV,ignorePrefix"`
+		NonGlobalEnv string `env:"GLOBAL_ENV"`
+		Other        string `env:"OTHER"`
+	}
+
+	type Config struct {
+		GlobalEnv string `env:"GLOBAL_ENV"`
+		Inner     Inner  `envPrefix:"INNER_"`
+	}
+
+	var cfg Config
+	isNoErr(t, ParseWithOptions(&cfg, Options{
+		Environment: map[string]string{
+			"GLOBAL_ENV":       "global_env",
+			"INNER_GLOBAL_ENV": "inner_global_env",
+			"INNER_OTHER":      "inner_other",
+		},
+	}))
+
+	isEqual(t, "global_env", cfg.GlobalEnv)
+	isEqual(t, "global_env", cfg.Inner.GlobalEnv)
+	isEqual(t, "inner_global_env", cfg.Inner.NonGlobalEnv)
+	isEqual(t, "inner_other", cfg.Inner.Other)
+}
+
 func TestNoEnvKey(t *testing.T) {
 	type Config struct {
 		Foo      string


### PR DESCRIPTION
Adds an option to ignore environment variable prefixes for certain keys, allowing some variables to be treated as global. This prevents the need to repeat the same variables with different prefixes across nested structs.