### PR TITLE
refactor: enable gocritic linter and fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,13 @@
 linters-settings:
+  gocritic:
+    enabled-checks:
+      - emptyStringTest
+      - evalOrder
+      - paramTypeCombine
+      - preferStringWriter
+      - sprintfQuotedString
+      - stringConcatSimplify
+      - yodaStyleExpr
   revive:
     rules:
       - name: line-length-limit
@@ -15,6 +24,7 @@ linters:
   enable:
     - thelper
     - gofumpt
+    - gocritic
     - tparallel
     - unconvert
     - unparam

--- a/env_test.go
+++ b/env_test.go
@@ -276,7 +276,7 @@ func TestParsesEnv(t *testing.T) {
 	t.Setenv("URL", tos(url1))
 	t.Setenv("URLS", toss(url1, url2))
 
-	t.Setenv("SEPSTRINGS", strings.Join([]string{str1, str2}, ":"))
+	t.Setenv("SEPSTRINGS", str1+":"+str2)
 
 	nonDefinedStr := "nonDefinedStr"
 	t.Setenv("NONDEFINED_STR", nonDefinedStr)
@@ -1485,7 +1485,7 @@ func TestFileBadFile(t *testing.T) {
 	}
 
 	err := Parse(&config{})
-	isErrorWithMessage(t, err, fmt.Sprintf(`env: could not load content of file "%s" from variable SECRET_KEY: open %s: %s`, filename, filename, oserr))
+	isErrorWithMessage(t, err, fmt.Sprintf("env: could not load content of file %q from variable SECRET_KEY: open %s: %s", filename, filename, oserr))
 	isTrue(t, errors.Is(err, LoadFileContentError{}))
 }
 

--- a/error.go
+++ b/error.go
@@ -68,7 +68,7 @@ func newParseError(sf reflect.StructField, err error) error {
 }
 
 func (e ParseError) Error() string {
-	return fmt.Sprintf(`parse error on field "%s" of type "%s": %v`, e.Name, e.Type, e.Err)
+	return fmt.Sprintf("parse error on field %q of type %q: %v", e.Name, e.Type, e.Err)
 }
 
 // The error occurs when pass something that is not a pointer to a struct to Parse
@@ -89,7 +89,7 @@ func newNoParserError(sf reflect.StructField) error {
 }
 
 func (e NoParserError) Error() string {
-	return fmt.Sprintf(`no parser found for field "%s" of type "%s"`, e.Name, e.Type)
+	return fmt.Sprintf("no parser found for field %q of type %q", e.Name, e.Type)
 }
 
 // This error occurs when the given tag is not supported.
@@ -109,7 +109,7 @@ func (e NoSupportedTagOptionError) Error() string {
 
 // This error occurs when the required variable is not set.
 //
-// deprecated: use VarIsNotSetError
+// Deprecated: use VarIsNotSetError.
 type EnvVarIsNotSetError = VarIsNotSetError
 
 // This error occurs when the required variable is not set.
@@ -127,7 +127,7 @@ func (e VarIsNotSetError) Error() string {
 
 // This error occurs when the variable which must be not empty is existing but has an empty value
 //
-// deprecated: use EmptyVarError
+// Deprecated: use EmptyVarError.
 type EmptyEnvVarError = EmptyVarError
 
 // This error occurs when the variable which must be not empty is existing but has an empty value
@@ -155,7 +155,7 @@ func newLoadFileContentError(filename, key string, err error) error {
 }
 
 func (e LoadFileContentError) Error() string {
-	return fmt.Sprintf(`could not load content of file "%s" from variable %s: %v`, e.Filename, e.Key, e.Err)
+	return fmt.Sprintf("could not load content of file %q from variable %s: %v", e.Filename, e.Key, e.Err)
 }
 
 // This error occurs when it's impossible to convert value using given parser.

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,6 @@ package env
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"reflect"
 )
@@ -400,7 +399,7 @@ func ExampleParseWithOptions_useFieldName() {
 // it.
 func ExampleParse_fromFile() {
 	f, _ := os.CreateTemp("", "")
-	_, _ = io.WriteString(f, "super secret")
+	_, _ = f.WriteString("super secret")
 	_ = f.Close()
 
 	type Config struct {


### PR DESCRIPTION
The PR enables [`gocritic`](https://golangci-lint.run/usage/linters/#gocritic) in golangci-lint's config and fixes appeared lint issues:

```
❯ golangci-lint run
env.go:606:40: emptyStringTest: replace `len(fieldParams.OwnKey) > 0` with `fieldParams.OwnKey != ""` (gocritic)
        if fieldParams.Required && !exists && len(fieldParams.OwnKey) > 0 {
                                              ^
env.go:266:12: evalOrder: may want to evaluate Parse(&t) before the return statement (gocritic)
        return t, Parse(&t)
                  ^
env.go:273:12: evalOrder: may want to evaluate ParseWithOptions(&t, opts) before the return statement (gocritic)
        return t, ParseWithOptions(&t, opts)
                  ^
env.go:641:1: paramTypeCombine: func(key, defaultValue string, defExists bool, envs map[string]string) (val string, exists bool, isDefault bool) could be replaced with func(key, defaultValue string, defExists bool, envs map[string]string) (val string, exists, isDefault bool) (gocritic)
func getOr(key, defaultValue string, defExists bool, envs map[string]string) (val string, exists bool, isDefault bool) {
^
error.go:112:1: deprecatedComment: use `Deprecated: ` (note the casing) instead of `deprecated: ` (gocritic)
// deprecated: use VarIsNotSetError
^
error.go:130:1: deprecatedComment: use `Deprecated: ` (note the casing) instead of `deprecated: ` (gocritic)
// deprecated: use EmptyVarError
^
error.go:71:9: sprintfQuotedString: use %q instead of "%s" for quoted strings (gocritic)
        return fmt.Sprintf(`parse error on field "%s" of type "%s": %v`, e.Name, e.Type, e.Err)
               ^
error.go:92:9: sprintfQuotedString: use %q instead of "%s" for quoted strings (gocritic)
        return fmt.Sprintf(`no parser found for field "%s" of type "%s"`, e.Name, e.Type)
               ^
error.go:158:9: sprintfQuotedString: use %q instead of "%s" for quoted strings (gocritic)
        return fmt.Sprintf(`could not load content of file "%s" from variable %s: %v`, e.Filename, e.Key, e.Err)
               ^
env_test.go:279:25: stringConcatSimplify: suggestion: str1 + ":" + str2 (gocritic)
        t.Setenv("SEPSTRINGS", strings.Join([]string{str1, str2}, ":"))
                               ^
example_test.go:403:9: preferStringWriter: f.WriteString("super secret") should be preferred to the io.WriteString(f, "super secret") (gocritic)
        _, _ = io.WriteString(f, "super secret")
               ^
```