### PR TITLE
refactor: simplify toMap on Windows implementation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,3 +20,4 @@ linters:
     - unparam
     - wastedassign
     - revive
+    - ineffassign

--- a/env_tomap_windows.go
+++ b/env_tomap_windows.go
@@ -7,16 +7,10 @@ import "strings"
 func toMap(env []string) map[string]string {
 	r := map[string]string{}
 	for _, e := range env {
-		p := strings.SplitN(e, "=", 2)
-
 		// On Windows, environment variables can start with '='. If so, Split at next character.
-		// See env_windows.go in the Go source: https://github.com/golang/go/blob/master/src/syscall/env_windows.go#L58
-		prefixEqualSign := false
-		if len(e) > 0 && e[0] == '=' {
-			e = e[1:]
-			prefixEqualSign = true
-		}
-		p = strings.SplitN(e, "=", 2)
+		// See env_windows.go in the Go source: https://github.com/golang/go/blob/go1.18/src/syscall/env_windows.go#L58
+		e, prefixEqualSign := strings.CutPrefix(e, "=")
+		p := strings.SplitN(e, "=", 2)
 		if prefixEqualSign {
 			p[0] = "=" + p[0]
 		}


### PR DESCRIPTION
The PR refactors `toMap` implementation. Additionally, it enables `ineffassign` linter that founds that `p := strings.SplitN(e, "=", 2)` is redundant.