### PR TITLE
fix: field 'unexported' has no environment variable

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -282,6 +282,8 @@ func TestParsesEnv(t *testing.T) {
 	t.Setenv("NONDEFINED_STR", nonDefinedStr)
 	t.Setenv("PRF_NONDEFINED_STR", nonDefinedStr)
 
+	t.Setenv("FOO", str1)
+
 	cfg := Config{}
 	isNoErr(t, Parse(&cfg))
 


### PR DESCRIPTION
In TestParsesEnv test case, there is no FOO environment variable, so it cannot test whether the unexported field is set successfully