### PR TITLE
The expand logic for env tag options has been modified, and the customOptions function has been refactored

### DIFF
--- a/env.go
+++ b/env.go
@@ -173,9 +173,9 @@ type Options struct {
 func (opts *Options) getRawEnv(s string) string {
 	val := opts.rawEnvVars[s]
 	if val == "" {
-		return opts.Environment[s]
+		val = opts.Environment[s]
 	}
-	return val
+	return os.Expand(val, opts.getRawEnv)
 }
 
 func defaultOptions() Options {

--- a/env_test.go
+++ b/env_test.go
@@ -1019,7 +1019,8 @@ func TestParseExpandWithDefaultOption(t *testing.T) {
 		CompoundDefault string `env:"HOST_PORT,expand" envDefault:"${HOST}:${PORT}"`
 		SimpleDefault   string `env:"DEFAULT,expand" envDefault:"def1"`
 		MixedDefault    string `env:"MIXED_DEFAULT,expand" envDefault:"$USER@${HOST}:${OTHER_PORT}"`
-		OverrideDefault string `env:"OVERRIDE_DEFAULT,expand" envDefault:"$THIS_SHOULD_NOT_BE_USED"`
+		OverrideDefault string `env:"OVERRIDE_DEFAULT,expand"`
+		DefaultIsExpand string `env:"DEFAULT_IS_EXPAND,expand" envDefault:"$THIS_IS_EXPAND"`
 		NoDefault       string `env:"NO_DEFAULT,expand"`
 	}
 
@@ -1027,6 +1028,7 @@ func TestParseExpandWithDefaultOption(t *testing.T) {
 	t.Setenv("USER", "jhon")
 	t.Setenv("THIS_IS_USED", "this is used instead")
 	t.Setenv("OVERRIDE_DEFAULT", "msg: ${THIS_IS_USED}")
+	t.Setenv("THIS_IS_EXPAND", "msg: ${THIS_IS_USED}")
 	t.Setenv("NO_DEFAULT", "$PORT:$OTHER_PORT")
 
 	cfg := config{}


### PR DESCRIPTION
1. If the environment variable key specified in env does not exist in the environment variables, and the key specified in envDefault is in the format of $var or ${var}, after being read, it is not replaced with the desired value.
2. the merging of customOptions and options has been written as the mergeOptions function.

I’m not sure if you accept these two commits.