### PR TITLE
Options.Environment: Do not merge with default env

### DIFF
--- a/env.go
+++ b/env.go
@@ -195,19 +195,20 @@ func mergeOptions[T any](target, source *T) {
 
 	targetType := targetPtr.Type()
 	for i := 0; i < targetPtr.NumField(); i++ {
+		fieldName := targetType.Field(i).Name
 		targetField := targetPtr.Field(i)
-		sourceField := sourcePtr.FieldByName(targetType.Field(i).Name)
+		sourceField := sourcePtr.FieldByName(fieldName)
 
 		if targetField.CanSet() && !isZero(sourceField) {
-			switch targetField.Kind() {
-			case reflect.Map:
+			// FuncMaps are being merged, while Environments must be overwritten
+			if fieldName == "FuncMap" {
 				if !sourceField.IsZero() {
 					iter := sourceField.MapRange()
 					for iter.Next() {
 						targetField.SetMapIndex(iter.Key(), iter.Value())
 					}
 				}
-			default:
+			} else {
 				targetField.Set(sourceField)
 			}
 		}

--- a/env_test.go
+++ b/env_test.go
@@ -2322,3 +2322,35 @@ func TestIssue350(t *testing.T) {
 	isNoErr(t, Parse(&cfg))
 	isEqual(t, map[string]string{"url": "https://foo.bar:2030"}, cfg.Map)
 }
+
+func TestEnvBleed(t *testing.T) {
+	type Config struct {
+		Foo string `env:"FOO"`
+	}
+
+	t.Setenv("FOO", "101")
+
+	t.Run("Default env with value", func(t *testing.T) {
+		var cfg Config
+		isNoErr(t, ParseWithOptions(&cfg, Options{}))
+		isEqual(t, "101", cfg.Foo)
+	})
+
+	t.Run("Empty env without value", func(t *testing.T) {
+		var cfg Config
+		isNoErr(t, ParseWithOptions(&cfg, Options{Environment: map[string]string{}}))
+		isEqual(t, "", cfg.Foo)
+	})
+
+	t.Run("Custom env with overwritten value", func(t *testing.T) {
+		var cfg Config
+		isNoErr(t, ParseWithOptions(&cfg, Options{Environment: map[string]string{"FOO": "202"}}))
+		isEqual(t, "202", cfg.Foo)
+	})
+
+	t.Run("Custom env without value", func(t *testing.T) {
+		var cfg Config
+		isNoErr(t, ParseWithOptions(&cfg, Options{Environment: map[string]string{"BAR": "202"}}))
+		isEqual(t, "", cfg.Foo)
+	})
+}


### PR DESCRIPTION
The commit 6f3a5c03be3c21cd7182233f189e97bf3972ced9 from PR #349, merged between the last two releases, changed the parsing logic for Options, especially allowing to merge map types. While this was already the case for Options.FuncMap, this breaks the API promise of Options.Environment to set "[e]nvironment keys and values that will be accessible for the service". In particular, this allowed an environment bleed while explicitly setting a custom environment, e.g., for testing purposes.

This change reverts merging a custom Options.Environment with the default environment, if set.