### PR TITLE
feat: support complex map types [WIP]

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -2411,3 +2411,27 @@ func TestEnvBleed(t *testing.T) {
 		isEqual(t, "", cfg.Foo)
 	})
 }
+
+func TestComplexConfigWithMap(t *testing.T) {
+	type Test struct {
+		Str string `env:"STR"`
+		Num int    `env:"NUM"`
+	}
+	type ComplexConfig struct {
+		Bar map[string]Test `envPrefix:"BAR_"`
+	}
+
+	t.Setenv("BAR_KEY1_STR", "b1t")
+	t.Setenv("BAR_KEY1_NUM", "201")
+	t.Setenv("BAR_KEY2_STR", "b2t")
+	t.Setenv("BAR_KEY2_NUM", "202")
+
+	cfg := ComplexConfig{Bar: make(map[string]Test)}
+
+	isNoErr(t, Parse(&cfg))
+
+	isEqual(t, "b1t", cfg.Bar["KEY1"].Str)
+	isEqual(t, 201, cfg.Bar["KEY1"].Num)
+	isEqual(t, "b2t", cfg.Bar["KEY2"].Str)
+	isEqual(t, 202, cfg.Bar["KEY2"].Num)
+}

--- a/env_test.go
+++ b/env_test.go
@@ -2413,25 +2413,42 @@ func TestEnvBleed(t *testing.T) {
 }
 
 func TestComplexConfigWithMap(t *testing.T) {
-	type Test struct {
-		Str string `env:"STR"`
-		Num int    `env:"NUM"`
-	}
-	type ComplexConfig struct {
-		Bar map[string]Test `envPrefix:"BAR_"`
-	}
+	t.Run("Default with string key", func(t *testing.T) {
 
-	t.Setenv("BAR_KEY1_STR", "b1t")
-	t.Setenv("BAR_KEY1_NUM", "201")
-	t.Setenv("BAR_KEY2_STR", "b2t")
-	t.Setenv("BAR_KEY2_NUM", "202")
+		type Test struct {
+			Str string `env:"DAT_STR"`
+			Num int    `env:"DAT_NUM"`
+		}
+		type ComplexConfig struct {
+			Bar map[string]Test `envPrefix:"BAR_"`
+		}
 
-	cfg := ComplexConfig{Bar: make(map[string]Test)}
+		t.Setenv("BAR_KEY1_T_DAT_STR", "b1t")
+		t.Setenv("BAR_KEY1_T_DAT_NUM", "201")
 
-	isNoErr(t, Parse(&cfg))
+		cfg := ComplexConfig{}
 
-	isEqual(t, "b1t", cfg.Bar["KEY1"].Str)
-	isEqual(t, 201, cfg.Bar["KEY1"].Num)
-	isEqual(t, "b2t", cfg.Bar["KEY2"].Str)
-	isEqual(t, 202, cfg.Bar["KEY2"].Num)
+		isNoErr(t, Parse(&cfg))
+
+		isEqual(t, "b1t", cfg.Bar["KEY1_T"].Str)
+	})
+
+	t.Run("Default with float key", func(t *testing.T) {
+		type Test struct {
+			Str string `env:"STR"`
+			Num int    `env:"NUM"`
+		}
+		type ComplexConfig struct {
+			Bar map[float64]Test `envPrefix:"BAR_"`
+		}
+
+		t.Setenv("BAR_10.17_STR", "b1t")
+		t.Setenv("BAR_7.9_NUM", "201")
+
+		cfg := ComplexConfig{}
+
+		isNoErr(t, Parse(&cfg))
+
+		isEqual(t, "b1t", cfg.Bar[10.17].Str)
+	})
 }


### PR DESCRIPTION
This PR adds support for complex map types, enabling users to configure environment variables that map to Go map structures.

This is useful when users might have a structure such as

```
type Test struct {
	Str string `env:"DAT_STR"`
	Num int    `env:"DAT_NUM"`
}
type ComplexConfig struct {
	Bar map[string]Test `envPrefix:"BAR_"`
}
```

Where the key to access the `Test` struct can be dynamic.

References https://github.com/caarlos0/env/issues/361

TODO:
This PR is currently a work in progress. At the moment, it only works if the map key contains no underscores. We need to implement a reliable way to determine where the dynamic key ends and where the struct field names (like STR or NUM) begin, this can also be a chain of nested structs, etc.
