### PR TITLE
feat: support complex map types

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,70 +88,12 @@ Pointers, slices and slices of pointers, and maps of those types are also suppor
 
 You may also add custom parsers for your types.
 
-### Supported Complex Types
-
-#### Slices of structs
-Use the `envPrefix` tag to define slices of structs. For example:
-```go
-type Server struct {
-    Host string `env:"HOST"`
-    Port int    `env:"PORT"`
-}
-type Config struct {
-    Servers []Server `envPrefix:"SERVER_"`
-}
-```
-
-Set environment variables with zero-based indices:
-```
-SERVER_0_HOST=localhost
-SERVER_0_PORT=8080
-SERVER_1_HOST=example.com
-SERVER_1_PORT=80
-```
-
-#### Maps of structs
-Use the `envPrefix` tag to define maps of structs. The library automatically handles the mapping:
-```go
-type Server struct {
-    Host string `env:"HOST"`
-    Port int    `env:"PORT"`
-}
-type Config struct {
-    Servers map[string]Server `envPrefix:"SERVER_"`
-}
-```
-
-Set environment variables using your chosen keys:
-```bash
-export SERVER_FOO_HOST=localhost
-export SERVER_FOO_PORT=8080
-```
+Additionally, the following are also supported
+- Slices of Structs
+- Map of Structs
 
 > [!IMPORTANT]
-> For nested maps, be careful with key naming to avoid conflicts.
-
-Example of nested maps:
-```go
-type Sub struct {
-    Value string `env:"VALUE"`
-}
-type Server struct {
-    Sub map[string]Sub `envPrefix:"SERVER_"`
-}
-type Config struct {
-    Entries map[string]Server `envPrefix:"ENTRIES_"`
-}
-```
-
-The library uses the rightmost `envPrefix` match as the key. For example:
-```bash
-# This won't work - VALUE becomes a key instead of a field
-export ENTRIES_FOO_SERVER_SERVER_SERVER_VALUE=foo
-
-# This works - KEY1 is the map key
-export ENTRIES_FOO_SERVER_SERVER_SERVER_KEY1_VALUE=foo
-```
+> For nested maps (i.e. map of structs inside map of structs), be careful with key naming to avoid conflicts.
 
 ### Tags
 
@@ -160,8 +102,8 @@ The following tags are provided:
 - `env`: sets the environment variable name and optionally takes the tag options described below
 - `envDefault`: sets the default value for the field
 - `envPrefix`: can be used in a field that is a complex type to set a prefix to all environment variables used in it
-- `envSeparator`: sets the character to be used to separate items in slices and maps (default: `,`)
-- `envKeyValSeparator`: sets the character to be used to separate keys and their values in maps (default: `:`)
+- `envSeparator`: sets the character to be used to separate items in slices and maps (which do not have structs as the value type) (default: `,`)
+- `envKeyValSeparator`: sets the character to be used to separate keys and their values in maps (which do not have structs as the value type) (default: `:`)
 
 ### `env` tag options
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,71 @@ Pointers, slices and slices of pointers, and maps of those types are also suppor
 
 You may also add custom parsers for your types.
 
+### Supported Complex Types
+
+#### Slices of structs
+Use the `envPrefix` tag to define slices of structs. For example:
+```go
+type Server struct {
+    Host string `env:"HOST"`
+    Port int    `env:"PORT"`
+}
+type Config struct {
+    Servers []Server `envPrefix:"SERVER_"`
+}
+```
+
+Set environment variables with zero-based indices:
+```
+SERVER_0_HOST=localhost
+SERVER_0_PORT=8080
+SERVER_1_HOST=example.com
+SERVER_1_PORT=80
+```
+
+#### Maps of structs
+Use the `envPrefix` tag to define maps of structs. The library automatically handles the mapping:
+```go
+type Server struct {
+    Host string `env:"HOST"`
+    Port int    `env:"PORT"`
+}
+type Config struct {
+    Servers map[string]Server `envPrefix:"SERVER_"`
+}
+```
+
+Set environment variables using your chosen keys:
+```bash
+export SERVER_FOO_HOST=localhost
+export SERVER_FOO_PORT=8080
+```
+
+> [!IMPORTANT]
+> For nested maps, be careful with key naming to avoid conflicts.
+
+Example of nested maps:
+```go
+type Sub struct {
+    Value string `env:"VALUE"`
+}
+type Server struct {
+    Sub map[string]Sub `envPrefix:"SERVER_"`
+}
+type Config struct {
+    Entries map[string]Server `envPrefix:"ENTRIES_"`
+}
+```
+
+The library uses the rightmost `envPrefix` match as the key. For example:
+```bash
+# This won't work - VALUE becomes a key instead of a field
+export ENTRIES_FOO_SERVER_SERVER_SERVER_VALUE=foo
+
+# This works - KEY1 is the map key
+export ENTRIES_FOO_SERVER_SERVER_SERVER_KEY1_VALUE=foo
+```
+
 ### Tags
 
 The following tags are provided:

--- a/env.go
+++ b/env.go
@@ -1052,10 +1052,11 @@ func traverseStruct(t reflect.Type, prefix string, opts Options, envVars map[str
 			prefix = prefix + fieldPrefix
 		}
 
+		ownKey, _ := parseKeyForOption(field.Tag.Get(opts.TagName))
+
 		// Get env tag if exists
-		envTag := field.Tag.Get(opts.TagName)
-		key := prefix + envTag
-		if envTag != "" {
+		key := prefix + ownKey
+		if ownKey != "" {
 			envVars[key] = false
 		}
 

--- a/env_test.go
+++ b/env_test.go
@@ -2559,7 +2559,7 @@ func TestComplexConfigWithMap(t *testing.T) {
 
 		err := Parse(&cfg)
 		isEqual(t, nil, cfg.Bar)
-		isErrorWithMessage(t, err, "env: parse error on field \"Bar\" of type \"map[string]env.Host\": env key unsupported for struct map \"Bar\"")
+		isErrorWithMessage(t, err, "env: parse error on field \"Bar\" of type \"map[string]env.Test\": malformed complex map struct for \"DAT_STR\"")
 	})
 
 	t.Run("Should allow an env tag without a value to be set on the map", func(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -2411,3 +2411,27 @@ func TestEnvBleed(t *testing.T) {
 		isEqual(t, "", cfg.Foo)
 	})
 }
+
+func TestComplexConfigWithMap(t *testing.T) {
+	type Test struct {
+		Str string `env:"STR"`
+		Num int    `env:"NUM"`
+	}
+	type ComplexConfig struct {
+		Bar map[string]Test `envPrefix:"BAR_"`
+	}
+
+	t.Setenv("BAR_KEY1_STR", "b1t")
+	t.Setenv("BAR_KEY1_NUM", "201")
+	t.Setenv("BAR_KEY2_STR", "b2t")
+	t.Setenv("BAR_KEY2_NUM", "202")
+
+	cfg := ComplexConfig{Bar: make(map[string]Test)}
+
+	isNoErr(t, Parse(&cfg))
+
+	isEqual(t, "b1t", cfg.Bar["KEY1"].Str)
+	isEqual(t, 201, cfg.Bar["KEY1"].Num)
+	isEqual(t, "b2t", cfg.Bar["KEY2"].Str)
+	isEqual(t, 202, cfg.Bar["KEY2"].Num)
+}

--- a/env_test.go
+++ b/env_test.go
@@ -2553,13 +2553,11 @@ func TestComplexConfigWithMap(t *testing.T) {
 			Bar map[string]Test `env:"VALUE,init"`
 		}
 
-		t.Setenv("KEY1_DAT_STR", "b1t")
-
 		cfg := ComplexConfig{}
 
 		err := Parse(&cfg)
 		isEqual(t, nil, cfg.Bar)
-		isErrorWithMessage(t, err, "env: parse error on field \"Bar\" of type \"map[string]env.Test\": malformed complex map struct for \"DAT_STR\"")
+		isErrorWithMessage(t, err, "env: parse error on field \"Bar\" of type \"map[string]env.Test\": env key unsupported for struct map \"Bar\"")
 	})
 
 	t.Run("Should allow an env tag without a value to be set on the map", func(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -2457,7 +2457,7 @@ func TestComplexConfigWithMap(t *testing.T) {
 		cfg := ComplexConfig{}
 
 		err := Parse(&cfg)
-		isErrorWithMessage(t, err, "env: parse error on field \"Bar\" of type \"map[string]env.Host\": malformed complex map struct for \"DAT_STR\"")
+		isErrorWithMessage(t, err, "env: parse error on field \"Bar\" of type \"map[string]env.Test\": malformed complex map struct for \"DAT_STR\"")
 	})
 
 	t.Run("Should parse map with struct without any matching env", func(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -2413,25 +2413,42 @@ func TestEnvBleed(t *testing.T) {
 }
 
 func TestComplexConfigWithMap(t *testing.T) {
-	type Test struct {
-		Str string `env:"STR"`
-		Num int    `env:"NUM"`
-	}
-	type ComplexConfig struct {
-		Bar map[string]Test `envPrefix:"BAR_"`
-	}
+	t.Run("Default with string key", func(t *testing.T) {
 
-	t.Setenv("BAR_KEY1_STR", "b1t")
-	t.Setenv("BAR_KEY1_NUM", "201")
-	t.Setenv("BAR_KEY2_STR", "b2t")
-	t.Setenv("BAR_KEY2_NUM", "202")
+		type Test struct {
+			Str string `env:"DAT_STR"`
+			Num int    `env:"DAT_NUM"`
+		}
+		type ComplexConfig struct {
+			Bar map[string]Test `envPrefix:"BAR_"`
+		}
 
-	cfg := ComplexConfig{Bar: make(map[string]Test)}
+		t.Setenv("BAR_KEY1_T_DAT_STR", "b1t")
+		t.Setenv("BAR_KEY1_T_DAT_NUM", "201")
 
-	isNoErr(t, Parse(&cfg))
+		cfg := ComplexConfig{}
 
-	isEqual(t, "b1t", cfg.Bar["KEY1"].Str)
-	isEqual(t, 201, cfg.Bar["KEY1"].Num)
-	isEqual(t, "b2t", cfg.Bar["KEY2"].Str)
-	isEqual(t, 202, cfg.Bar["KEY2"].Num)
+		isNoErr(t, Parse(&cfg))
+
+		isEqual(t, "b1t", cfg.Bar["KEY1_T"].Str)
+	})
+
+	t.Run("Default with float key", func(t *testing.T) {
+		type Test struct {
+			Str string `env:"STR"`
+			Num int    `env:"NUM"`
+		}
+		type ComplexConfig struct {
+			Bar map[float64]Test `envPrefix:"BAR_"`
+		}
+
+		t.Setenv("BAR_10.17_STR", "b1t")
+		t.Setenv("BAR_7.9_NUM", "201")
+
+		cfg := ComplexConfig{}
+
+		isNoErr(t, Parse(&cfg))
+
+		isEqual(t, "b1t", cfg.Bar[10.17].Str)
+	})
 }


### PR DESCRIPTION
This PR adds support for complex map types, enabling users to configure environment variables that map to Go map structures. References https://github.com/caarlos0/env/issues/361 (Note: This is the same as this PR https://github.com/caarlos0/env/pull/362, The source branch was changed thus the PR was reopened separately)

This is useful when users might have a structure such as

```
type SubEntry struct {
	Str string `env:"DAT_STR"`
	Num int    `env:"DAT_NUM"`
}
type ComplexConfig struct {
	Bar map[string]Test `envPrefix:"BAR_"`
}
```

Where the key to access the `SubEntry` struct can be dynamic.

We need to figure out the key of the map, the algorithm for this essentially reads as follows
> Traverse the struct of the map and find out the sub keys it has and use the matching key to trim the suffix of the map environment variable to find the key.
 
This results in the following restrictions, if a user was to use "A map of structs inside a map of structs", it becomes harder to figure out the key, thus in these cases instead of trimming the suffix, we split the string using the envPrefix of the sub (inner) map of the last recurring (rightmost) substring. Users should be more aware with the naming of the tags (`env` and `envPrefix`) and should make them unique, when there are nested maps involved.

Test cases with examples for these cases are available, e.g. :- https://github.com/caarlos0/env/pull/362/files#diff-19e9f6a4b37808acd7acef7094d89f6f9ca8e7c6409ab9b583fa3fac69000ec6R2529

We also ignore env tag options like `,init` etc on the `map field` itself, this is similar to how slices of structs behaves


