### PR TITLE
fix: allow env var to override non-zero struct values (#364)

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -2411,3 +2411,18 @@ func TestEnvBleed(t *testing.T) {
 		isEqual(t, "", cfg.Foo)
 	})
 }
+
+func TestParse_Bug364EnvVarOverridesStructValue(t *testing.T) {
+	t.Setenv("USERNAME", "user1")
+
+	type cfg struct {
+		Username string `env:"USERNAME" envDefault:"admin"`
+	}
+	c := cfg{Username: "root"}
+
+	isNoErr(t, ParseWithOptions(&c, Options{
+		SetDefaultsForZeroValuesOnly: true,
+	}))
+
+	isEqual(t, c.Username, "user1")
+}


### PR DESCRIPTION
Fixes #364

### What this does

- Ensures that environment variables override struct values,
  even when SetDefaultsForZeroValuesOnly is true.
- Adjusts get(...) to return a flag indicating the value source.
- Modifies setField to prioritize env vars.
- Adds a test that reproduces the bug.

### Why

The current logic prevents environment values from being applied
when the struct field is non-zero, which is not the intended behavior.
