### PR TITLE
fix: use Key instead of OwnKey in rawEnvVars to properly reference existing defaults in complex structs

### DIFF
--- a/env.go
+++ b/env.go
@@ -604,7 +604,7 @@ func get(fieldParams FieldParams, opts Options) (val string, err error) {
 		val = os.Expand(val, opts.getRawEnv)
 	}
 
-	opts.rawEnvVars[fieldParams.OwnKey] = val
+	opts.rawEnvVars[fieldParams.Key] = val
 
 	if fieldParams.Unset {
 		defer os.Unsetenv(fieldParams.Key)

--- a/env_test.go
+++ b/env_test.go
@@ -991,6 +991,12 @@ func TestParseExpandOption(t *testing.T) {
 		ExpandKey   string `env:"EXPAND_KEY"`
 		CompoundKey string `env:"HOST_PORT,expand" envDefault:"${HOST}:${PORT}"`
 		Default     string `env:"DEFAULT,expand" envDefault:"def1"`
+		Component   struct {
+			Port     int `env:"PORT" envDefault:"5000"`
+			Internal struct {
+				Host string `env:"INTERNAL_HOST,expand" envDefault:"${HOST}:${COMPONENT_PORT}"`
+			}
+		} `envPrefix:"COMPONENT_"`
 	}
 
 	t.Setenv("HOST", "localhost")
@@ -1008,6 +1014,7 @@ func TestParseExpandOption(t *testing.T) {
 	isEqual(t, "qwerty12345", cfg.ExpandKey)
 	isEqual(t, "localhost:3000", cfg.CompoundKey)
 	isEqual(t, "def1", cfg.Default)
+	isEqual(t, "localhost:5000", cfg.Component.Internal.Host)
 }
 
 func TestParseExpandWithDefaultOption(t *testing.T) {


### PR DESCRIPTION
currently it's impossible to expand variable from other struct field, if configuration struct is not plain
in a given below example Config.Component.Endpoint.Value can be only obtained from env variable, but not from default value of Config.Component.Host
```
type Config struct {
  Name string `env:"NAME" envDefault:"some-name"`
  Component struct {
    Host string `env:"HOST" envDefault:"localhost"`
    Endpoint struct {
      Value string `env:"VALUE,expand" envDefault:"${COMPONENT_HOST}"`
    }
  } `envPrefix:"COMPONENT_"`
}
```