### PR TITLE
fix: apply custom parser to pointer-to-custom-type fields

### DIFF
--- a/env.go
+++ b/env.go
@@ -380,7 +380,12 @@ func doParseField(
 		return nil
 	}
 	if refField.Kind() == reflect.Ptr && refField.Elem().Kind() == reflect.Struct && !refField.IsNil() {
-		return parseInternal(refField.Interface(), processField, optionsWithEnvPrefix(refTypeField, opts))
+		// If the field has its own env tag, don't recurse into the struct.
+		// Let it fall through to setField, which handles custom parsers.
+		ownKey, _ := parseKeyForOption(refTypeField.Tag.Get(opts.TagName))
+		if ownKey == "" && !opts.UseFieldNameByDefault {
+			return parseInternal(refField.Interface(), processField, optionsWithEnvPrefix(refTypeField, opts))
+		}
 	}
 	if refField.Kind() == reflect.Struct && refField.CanAddr() && refField.Type().Name() == "" {
 		return parseInternal(refField.Addr().Interface(), processField, optionsWithEnvPrefix(refTypeField, opts))

--- a/env_test.go
+++ b/env_test.go
@@ -2417,3 +2417,34 @@ func TestEnvBleed(t *testing.T) {
 		isEqual(t, "", cfg.Foo)
 	})
 }
+
+func TestCustomParserPointerToCustomType(t *testing.T) {
+	// Regression test for #385
+	type foo struct {
+		name string
+	}
+
+	t.Setenv("VAR_CUSTOM", "test")
+	t.Setenv("BLAH_CUSTOM", "test3")
+
+	type config struct {
+		Var foo  `env:"VAR_CUSTOM"`
+		Foo *foo `env:"BLAH_CUSTOM"`
+	}
+
+	cfg := &config{
+		Var: foo{"var"},
+		Foo: &foo{"foo"},
+	}
+
+	err := ParseWithOptions(cfg, Options{FuncMap: map[reflect.Type]ParserFunc{
+		reflect.TypeOf(foo{}): func(v string) (interface{}, error) {
+			return foo{name: v}, nil
+		},
+	}})
+
+	isNoErr(t, err)
+	isEqual(t, "test", cfg.Var.name)
+	isTrue(t, cfg.Foo != nil)
+	isEqual(t, "test3", cfg.Foo.name)
+}


### PR DESCRIPTION
## Summary

Fixes #385

When a struct field is a pointer to a custom type (e.g. ) with an SHELL=/bin/bash
WSL2_GUI_APPS_ENABLED=1
WSL_DISTRO_NAME=Ubuntu-24.04
NAME=lihanPC02
PWD=/mnt/c/lihan_work/opensource
LOGNAME=lihan
HOME=/home/lihan
LANG=C.UTF-8
WSL_INTEROP=/run/WSL/23616_interop
WAYLAND_DISPLAY=wayland-0
TERM=xterm-256color
USER=lihan
DISPLAY=:0
SHLVL=0
XDG_RUNTIME_DIR=/run/user/1000/
WSLENV=
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib
DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
HOSTTYPE=x86_64
PULSE_SERVER=unix:/mnt/wslg/PulseServer
_=/usr/bin/env tag and a custom parser is registered for the underlying type, the parser was never invoked. Instead,  recursed into the pointed-to struct, looking for env-tagged fields inside it.

The fix checks whether the field has its own SHELL=/bin/bash
WSL2_GUI_APPS_ENABLED=1
WSL_DISTRO_NAME=Ubuntu-24.04
NAME=lihanPC02
PWD=/mnt/c/lihan_work/opensource
LOGNAME=lihan
HOME=/home/lihan
LANG=C.UTF-8
WSL_INTEROP=/run/WSL/23616_interop
WAYLAND_DISPLAY=wayland-0
TERM=xterm-256color
USER=lihan
DISPLAY=:0
SHLVL=0
XDG_RUNTIME_DIR=/run/user/1000/
WSLENV=
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib
DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
HOSTTYPE=x86_64
PULSE_SERVER=unix:/mnt/wslg/PulseServer
_=/usr/bin/env tag before recursing into pointer-to-struct fields. If an env tag is present, the field falls through to , which correctly invokes the custom parser.

## Test plan

- [x] Added  regression test covering both non-pointer and pointer-to-custom-type fields with custom parsers
- [x] All existing custom parser tests pass (, , etc.)
- [x] Two pre-existing test failures (, ) are unrelated — they also fail on unmodified main
- [x] gofmt clean
