### PR TITLE
respect env values over non-zero fields under SetDefaultsForZeroValuesOnly

### DIFF
--- a/env.go
+++ b/env.go
@@ -499,12 +499,17 @@ func doParseSlice(ref reflect.Value, processField processFieldFn, opts Options) 
 }
 
 func setField(refField reflect.Value, refTypeField reflect.StructField, opts Options, fieldParams FieldParams) error {
-	value, err := get(fieldParams, opts)
+	value, isDefault, err := get(fieldParams, opts)
 	if err != nil {
 		return err
 	}
 
-	if value != "" && (!opts.SetDefaultsForZeroValuesOnly || refField.IsZero()) {
+	// SetDefaultsForZeroValuesOnly is about defaults: a real env value
+	// should still win over a non-zero field. The previous form treated
+	// any non-empty value as a default, so an explicit env override was
+	// silently dropped when the destination already held something
+	// non-zero. See #364.
+	if value != "" && (!isDefault || !opts.SetDefaultsForZeroValuesOnly || refField.IsZero()) {
 		return set(refField, refTypeField, value, opts.FuncMap)
 	}
 
@@ -590,8 +595,8 @@ func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, err
 	return result, nil
 }
 
-func get(fieldParams FieldParams, opts Options) (val string, err error) {
-	var exists, isDefault bool
+func get(fieldParams FieldParams, opts Options) (val string, isDefault bool, err error) {
+	var exists bool
 
 	val, exists, isDefault = getOr(
 		fieldParams.Key,
@@ -611,18 +616,18 @@ func get(fieldParams FieldParams, opts Options) (val string, err error) {
 	}
 
 	if fieldParams.Required && !exists && fieldParams.OwnKey != "" {
-		return "", newVarIsNotSetError(fieldParams.Key)
+		return "", false, newVarIsNotSetError(fieldParams.Key)
 	}
 
 	if fieldParams.NotEmpty && val == "" {
-		return "", newEmptyVarError(fieldParams.Key)
+		return "", false, newEmptyVarError(fieldParams.Key)
 	}
 
 	if fieldParams.LoadFile && val != "" {
 		filename := val
 		val, err = getFromFile(filename)
 		if err != nil {
-			return "", newLoadFileContentError(filename, fieldParams.Key, err)
+			return "", false, newLoadFileContentError(filename, fieldParams.Key, err)
 		}
 	}
 
@@ -631,7 +636,7 @@ func get(fieldParams FieldParams, opts Options) (val string, err error) {
 			opts.OnSet(fieldParams.Key, val, isDefault)
 		}
 	}
-	return val, err
+	return val, isDefault, err
 }
 
 // split the env tag's key into the expected key and desired option, if any.

--- a/env_test.go
+++ b/env_test.go
@@ -2259,6 +2259,22 @@ func TestSetDefaultsForZeroValuesOnly(t *testing.T) {
 	}
 }
 
+// Regression for #364: SetDefaultsForZeroValuesOnly is about defaults.
+// An env value set in the environment should still win over a non-zero
+// field, otherwise users can't override pre-populated config via env at
+// all.
+func TestSetDefaultsForZeroValuesOnly_EnvOverridesNonZero(t *testing.T) {
+	type Config struct {
+		Username string `env:"USERNAME" envDefault:"admin"`
+	}
+	cfg := Config{Username: "root"}
+	isNoErr(t, ParseWithOptions(&cfg, Options{
+		Environment:                  map[string]string{"USERNAME": "user1"},
+		SetDefaultsForZeroValuesOnly: true,
+	}))
+	isEqual(t, "user1", cfg.Username)
+}
+
 func TestParseWithOptionsRenamedPrefix(t *testing.T) {
 	type Config struct {
 		Str string `env:"STR"`


### PR DESCRIPTION
Fixes #364.

\`SetDefaultsForZeroValuesOnly\` is about *defaults*: an env var that's actually set in the environment should still take precedence over an already-populated field. The previous check treated any non-empty value the same way, so:

\`\`\`go
type Config struct {
    Username string \`env:\"USERNAME\" envDefault:\"admin\"\`
}
cfg := Config{Username: \"root\"}
env.ParseWithOptions(&cfg, env.Options{
    Environment:                  map[string]string{\"USERNAME\": \"user1\"},
    SetDefaultsForZeroValuesOnly: true,
})
// got:  \"root\"
// want: \"user1\"
\`\`\`

Plumb the \`isDefault\` flag (which \`getOr\` already computes) out of \`get()\` and only skip setting when the value came from a default. Real env values keep flowing through. Existing \`TestSetDefaultsForZeroValuesOnly\` cases still pass.

Added \`TestSetDefaultsForZeroValuesOnly_EnvOverridesNonZero\` for the regression.