### PR TITLE
docs: remove starchart.cc embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,3 @@ Eventual bug fixes will keep being merged.
 ## Related projects
 
 - [envdoc](https://github.com/g4s8/envdoc) - generate documentation for environment variables from `env` tags
-
-## Stargazers over time
-
-[![Stargazers over time](https://starchart.cc/caarlos0/env.svg?variant=adaptive)](https://starchart.cc/caarlos0/env)


### PR DESCRIPTION
`starchart.cc` is rate limited and rendering a broken image in the README, so this removes the embed and its (now-empty) stargazers section.

Refs: https://github.com/caarlos0/starcharts/issues/260
