### PR TITLE
fix: apply FuncMap parsers to pointer-to-custom-type fields

### DIFF
--- a/env.go
+++ b/env.go
@@ -380,7 +380,12 @@ func doParseField(
 		return nil
 	}
 	if refField.Kind() == reflect.Ptr && refField.Elem().Kind() == reflect.Struct && !refField.IsNil() {
-		return parseInternal(refField.Interface(), processField, optionsWithEnvPrefix(refTypeField, opts))
+		// If the field has its own env key, treat it as a single value (custom
+		// parser / TextUnmarshaler) instead of recursing into nested fields.
+		ownKey, _ := parseKeyForOption(refTypeField.Tag.Get(opts.TagName))
+		if ownKey == "" && !opts.UseFieldNameByDefault {
+			return parseInternal(refField.Interface(), processField, optionsWithEnvPrefix(refTypeField, opts))
+		}
 	}
 	if refField.Kind() == reflect.Struct && refField.CanAddr() && refField.Type().Name() == "" {
 		return parseInternal(refField.Addr().Interface(), processField, optionsWithEnvPrefix(refTypeField, opts))
@@ -671,6 +676,9 @@ func set(field reflect.Value, sf reflect.StructField, value string, funcMap map[
 	fieldee := field
 	if typee.Kind() == reflect.Ptr {
 		typee = typee.Elem()
+		if field.IsNil() {
+			field.Set(reflect.New(typee))
+		}
 		fieldee = field.Elem()
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -2417,3 +2417,52 @@ func TestEnvBleed(t *testing.T) {
 		isEqual(t, "", cfg.Foo)
 	})
 }
+
+
+func TestCustomParserPointerToCustomType(t *testing.T) {
+	// Regression for #385: *CustomType fields must use FuncMap parsers.
+	type foo struct {
+		name string
+	}
+
+	t.Setenv("VAR_CUSTOM", "test")
+	t.Setenv("OTHER_CUSTOM", "test2")
+	t.Setenv("BLAH_CUSTOM", "test3")
+
+	type bar struct {
+		Name string `env:"OTHER_CUSTOM"`
+		Foo  *foo   `env:"BLAH_CUSTOM"`
+	}
+
+	type config struct {
+		Var   foo  `env:"VAR_CUSTOM"`
+		Foo   *foo `env:"BLAH_CUSTOM"`
+		NilFoo *foo `env:"BLAH_CUSTOM"`
+		Other *bar
+	}
+
+	cfg := &config{
+		Var: foo{"var"},
+		Foo: &foo{"foo"},
+		Other: &bar{
+			Name: "name",
+			Foo:  &foo{"foo"},
+		},
+	}
+
+	err := ParseWithOptions(cfg, Options{FuncMap: map[reflect.Type]ParserFunc{
+		reflect.TypeOf(foo{}): func(v string) (interface{}, error) {
+			return foo{name: v}, nil
+		},
+	}})
+
+	isNoErr(t, err)
+	isEqual(t, "test", cfg.Var.name)
+	isTrue(t, cfg.Foo != nil)
+	isEqual(t, "test3", cfg.Foo.name)
+	isTrue(t, cfg.NilFoo != nil)
+	isEqual(t, "test3", cfg.NilFoo.name)
+	isEqual(t, "test2", cfg.Other.Name)
+	isTrue(t, cfg.Other.Foo != nil)
+	isEqual(t, "test3", cfg.Other.Foo.name)
+}


### PR DESCRIPTION
## Summary
When a field is a pointer to a custom struct type and has its own `env` tag, `doParseField` always recursed into nested fields and never applied `FuncMap` parsers / `setField` for that pointer field.

That made this fail:

```go
type foo struct{ name string }
type config struct {
  Foo *foo `env:"BLAH_CUSTOM"`
}
ParseWithOptions(&cfg, Options{FuncMap: map[reflect.Type]ParserFunc{
  reflect.TypeOf(foo{}): func(v string) (any, error) { return foo{name: v}, nil },
}})
```

`Foo` kept its pre-parse value instead of being rebuilt from the env string.

## Fix
1. In `doParseField`, only recurse into `*Struct` when the field has **no** own env key (and field-name defaulting is off). Own keys fall through to `setField`.
2. In `set`, allocate a nil pointer target before writing a custom-parser value (so `NilFoo *foo` works too).

## Test plan
- [x] `TestCustomParserPointerToCustomType` (includes nested `Other *bar` + nil pointer target)
- [x] full `go test .` (with ambient `PORT` unset)

Fixes #385
