### PR TITLE
feat: add KEY_FILE suffix support for Docker secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The following tags are provided:
 
 Here are all the options available for the `env` tag:
 
+- `,allowFileSuffix`: when the variable is empty/unset, if `KEY_FILE` is set, read the value from that file (Docker secrets pattern)
 - `,expand`: expands environment variables, e.g. `FOO_${BAR}`
 - `,file`: instructs that the content of the variable is a path to a file that should be read
 - `,init`: initialize nil pointers
@@ -121,6 +122,7 @@ There are a few options available in the functions that end with `WithOptions`:
 - `OnSet`: allows to hook into the `env` parsing and do something when a value is set
 - `Prefix`: prefix to be used in all environment variables
 - `UseFieldNameByDefault`: defines whether or not `env` should use the field name by default if the `env` key is missing
+- `AllowFileSuffix`: enable the Docker secrets `KEY`/`KEY_FILE` pattern for all fields
 - `FuncMap`: custom parse functions for custom types
 
 ### Documentation and examples

--- a/env.go
+++ b/env.go
@@ -168,6 +168,12 @@ type Options struct {
 	// Useful for mixing default values from `envDefault` and struct initialization
 	SetDefaultsForZeroValuesOnly bool
 
+	// AllowFileSuffix enables the Docker secrets pattern globally: when a
+	// variable KEY is empty or unset, and KEY_FILE is set, the value is read
+	// from the file path given by KEY_FILE.
+	// This can also be enabled per-field with the `allowFileSuffix` tag option.
+	AllowFileSuffix bool
+
 	// Custom parse functions for different types.
 	FuncMap map[reflect.Type]ParserFunc
 
@@ -248,6 +254,7 @@ func optionsWithSliceEnvPrefix(opts Options, index int) Options {
 		Prefix:                       fmt.Sprintf("%s%d_", opts.Prefix, index),
 		UseFieldNameByDefault:        opts.UseFieldNameByDefault,
 		SetDefaultsForZeroValuesOnly: opts.SetDefaultsForZeroValuesOnly,
+		AllowFileSuffix:              opts.AllowFileSuffix,
 		FuncMap:                      opts.FuncMap,
 		rawEnvVars:                   opts.rawEnvVars,
 	}
@@ -264,6 +271,7 @@ func optionsWithEnvPrefix(field reflect.StructField, opts Options) Options {
 		Prefix:                       opts.Prefix + field.Tag.Get(opts.PrefixTagName),
 		UseFieldNameByDefault:        opts.UseFieldNameByDefault,
 		SetDefaultsForZeroValuesOnly: opts.SetDefaultsForZeroValuesOnly,
+		AllowFileSuffix:              opts.AllowFileSuffix,
 		FuncMap:                      opts.FuncMap,
 		rawEnvVars:                   opts.rawEnvVars,
 	}
@@ -545,6 +553,7 @@ type FieldParams struct {
 	Expand          bool
 	Init            bool
 	Ignored         bool
+	AllowFileSuffix bool
 }
 
 func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, error) {
@@ -580,6 +589,8 @@ func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, err
 			result.Expand = true
 		case "init":
 			result.Init = true
+		case "allowFileSuffix":
+			result.AllowFileSuffix = true
 		case "-":
 			result.Ignored = true
 		default:
@@ -599,6 +610,23 @@ func get(fieldParams FieldParams, opts Options) (val string, err error) {
 		fieldParams.HasDefaultValue,
 		opts.Environment,
 	)
+
+	// Docker secrets pattern: when KEY is empty/unset and KEY_FILE is set,
+	// load the value from the file path given by KEY_FILE.
+	if (opts.AllowFileSuffix || fieldParams.AllowFileSuffix) && fieldParams.Key != "" {
+		raw, rawExists := opts.Environment[fieldParams.Key]
+		if !rawExists || raw == "" {
+			fileKey := fieldParams.Key + "_FILE"
+			if filePath, ok := opts.Environment[fileKey]; ok && filePath != "" {
+				val, err = getFromFile(filePath)
+				if err != nil {
+					return "", newLoadFileContentError(filePath, fileKey, err)
+				}
+				exists = true
+				isDefault = false
+			}
+		}
+	}
 
 	if fieldParams.Expand {
 		val = os.Expand(val, opts.getRawEnv)

--- a/env_test.go
+++ b/env_test.go
@@ -1515,6 +1515,181 @@ func TestFileWithDefault(t *testing.T) {
 	isEqual(t, "secret", cfg.SecretKey)
 }
 
+func TestAllowFileSuffixTag(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	t.Setenv("PASSWORD_FILE", file)
+
+	cfg := config{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "from-file", cfg.Password)
+}
+
+func TestAllowFileSuffixOption(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	cfg := config{}
+	isNoErr(t, ParseWithOptions(&cfg, Options{
+		AllowFileSuffix: true,
+		Environment: map[string]string{
+			"PASSWORD_FILE": file,
+		},
+	}))
+	isEqual(t, "from-file", cfg.Password)
+}
+
+func TestAllowFileSuffixPrefersEnvOverFile(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	t.Setenv("PASSWORD", "from-env")
+	t.Setenv("PASSWORD_FILE", file)
+
+	cfg := config{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "from-env", cfg.Password)
+}
+
+func TestAllowFileSuffixEmptyEnvFallsBackToFile(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	t.Setenv("PASSWORD", "")
+	t.Setenv("PASSWORD_FILE", file)
+
+	cfg := config{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "from-file", cfg.Password)
+}
+
+func TestAllowFileSuffixOverridesDefault(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix" envDefault:"default-password"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	t.Setenv("PASSWORD_FILE", file)
+
+	cfg := config{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "from-file", cfg.Password)
+}
+
+func TestAllowFileSuffixDefaultWhenNoFile(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix" envDefault:"default-password"`
+	}
+
+	cfg := config{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "default-password", cfg.Password)
+}
+
+func TestAllowFileSuffixRequired(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix,required"`
+	}
+
+	err := Parse(&config{})
+	isErrorWithMessage(t, err, `env: required environment variable "PASSWORD" is not set`)
+	isTrue(t, errors.Is(err, VarIsNotSetError{}))
+}
+
+func TestAllowFileSuffixRequiredSatisfiedByFile(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix,required"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	t.Setenv("PASSWORD_FILE", file)
+
+	cfg := config{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "from-file", cfg.Password)
+}
+
+func TestAllowFileSuffixBadFile(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD,allowFileSuffix"`
+	}
+
+	filename := "not-a-real-file"
+	t.Setenv("PASSWORD_FILE", filename)
+
+	oserr := "no such file or directory"
+	if runtime.GOOS == "windows" {
+		oserr = "The system cannot find the file specified."
+	}
+
+	err := Parse(&config{})
+	isErrorWithMessage(t, err, fmt.Sprintf("env: could not load content of file %q from variable PASSWORD_FILE: open %s: %s", filename, filename, oserr))
+	isTrue(t, errors.Is(err, LoadFileContentError{}))
+}
+
+func TestAllowFileSuffixDisabledByDefault(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	t.Setenv("PASSWORD_FILE", file)
+
+	cfg := config{}
+	isNoErr(t, Parse(&cfg))
+	isEqual(t, "", cfg.Password)
+}
+
+func TestAllowFileSuffixWithPrefix(t *testing.T) {
+	type config struct {
+		Password string `env:"PASSWORD"`
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "password")
+	isNoErr(t, os.WriteFile(file, []byte("from-file"), 0o660))
+
+	cfg := config{}
+	isNoErr(t, ParseWithOptions(&cfg, Options{
+		Prefix:          "DB_",
+		AllowFileSuffix: true,
+		Environment: map[string]string{
+			"DB_PASSWORD_FILE": file,
+		},
+	}))
+	isEqual(t, "from-file", cfg.Password)
+}
+
 func TestCustomSliceType(t *testing.T) {
 	type customslice []byte
 
@@ -1757,16 +1932,17 @@ func TestErrorIs(t *testing.T) {
 }
 
 type FieldParamsConfig struct {
-	Simple         []string `env:"SIMPLE"`
-	WithoutEnv     string
-	privateWithEnv string `env:"PRIVATE_WITH_ENV"` //nolint:unused
-	WithDefault    string `env:"WITH_DEFAULT" envDefault:"default"`
-	Required       string `env:"REQUIRED,required"`
-	File           string `env:"FILE,file"`
-	Unset          string `env:"UNSET,unset"`
-	NotEmpty       string `env:"NOT_EMPTY,notEmpty"`
-	Expand         string `env:"EXPAND,expand"`
-	NestedConfig   struct {
+	Simple          []string `env:"SIMPLE"`
+	WithoutEnv      string
+	privateWithEnv  string `env:"PRIVATE_WITH_ENV"` //nolint:unused
+	WithDefault     string `env:"WITH_DEFAULT" envDefault:"default"`
+	Required        string `env:"REQUIRED,required"`
+	File            string `env:"FILE,file"`
+	Unset           string `env:"UNSET,unset"`
+	NotEmpty        string `env:"NOT_EMPTY,notEmpty"`
+	Expand          string `env:"EXPAND,expand"`
+	AllowFileSuffix string `env:"ALLOW_FILE_SUFFIX,allowFileSuffix"`
+	NestedConfig    struct {
 		Simple []string `env:"SIMPLE"`
 	} `envPrefix:"NESTED_"`
 }
@@ -1784,6 +1960,7 @@ func TestGetFieldParams(t *testing.T) {
 		{OwnKey: "UNSET", Key: "UNSET", Unset: true},
 		{OwnKey: "NOT_EMPTY", Key: "NOT_EMPTY", NotEmpty: true},
 		{OwnKey: "EXPAND", Key: "EXPAND", Expand: true},
+		{OwnKey: "ALLOW_FILE_SUFFIX", Key: "ALLOW_FILE_SUFFIX", AllowFileSuffix: true},
 		{OwnKey: "SIMPLE", Key: "NESTED_SIMPLE"},
 	}
 	isTrue(t, len(params) == len(expectedParams))
@@ -1804,6 +1981,7 @@ func TestGetFieldParamsWithPrefix(t *testing.T) {
 		{OwnKey: "UNSET", Key: "FOO_UNSET", Unset: true},
 		{OwnKey: "NOT_EMPTY", Key: "FOO_NOT_EMPTY", NotEmpty: true},
 		{OwnKey: "EXPAND", Key: "FOO_EXPAND", Expand: true},
+		{OwnKey: "ALLOW_FILE_SUFFIX", Key: "FOO_ALLOW_FILE_SUFFIX", AllowFileSuffix: true},
 		{OwnKey: "SIMPLE", Key: "FOO_NESTED_SIMPLE"},
 	}
 	isTrue(t, len(params) == len(expectedParams))

--- a/error.go
+++ b/error.go
@@ -94,7 +94,7 @@ func (e NoParserError) Error() string {
 
 // NoSupportedTagOptionError occurs when the given tag is not supported.
 // Built-in supported tags: "", "file", "required", "unset", "notEmpty",
-// "expand", "envDefault", and "envSeparator".
+// "expand", "init", "allowFileSuffix", "envDefault", and "envSeparator".
 type NoSupportedTagOptionError struct {
 	Tag string
 }

--- a/example_test.go
+++ b/example_test.go
@@ -414,6 +414,26 @@ func ExampleParse_fromFile() {
 	// Output: {Secret:super secret}
 }
 
+// The `allowFileSuffix` tag option (or Options.AllowFileSuffix) enables the
+// Docker secrets pattern: when KEY is empty or unset and KEY_FILE is set, the
+// value is read from the file path given by KEY_FILE.
+func ExampleParse_allowFileSuffix() {
+	f, _ := os.CreateTemp("", "")
+	_, _ = f.WriteString("super secret")
+	_ = f.Close()
+
+	type Config struct {
+		Password string `env:"PASSWORD,allowFileSuffix"`
+	}
+	os.Setenv("PASSWORD_FILE", f.Name())
+	var cfg Config
+	if err := Parse(&cfg); err != nil {
+		fmt.Println(err)
+	}
+	fmt.Printf("%+v", cfg)
+	// Output: {Password:super secret}
+}
+
 // TODO: envSeperator
 //
 


### PR DESCRIPTION
## Summary

Adds support for the Docker secrets `_FILE` pattern requested in #422.

When a variable `KEY` is empty or unset and `KEY_FILE` is set, the value is read from the file path given by `KEY_FILE`.

### Usage

**Per-field:**

```go
type Config struct {
    Password string `env:"PASSWORD,allowFileSuffix"`
}
```

**Global:**

```go
env.ParseWithOptions(&cfg, env.Options{
    AllowFileSuffix: true,
})
```

### Behavior

- Direct env value takes precedence over `KEY_FILE` when both are set
- Empty env values fall back to `KEY_FILE`
- `KEY_FILE` takes precedence over `envDefault`
- Satisfies `required` when the file provides a value
- File read failures return `LoadFileContentError`
- Disabled by default (opt-in via tag or option)

Works with prefixes (`DB_PASSWORD` → `DB_PASSWORD_FILE`).

Closes #422

## Test plan

- [x] Unit tests with temp files covering tag, option, precedence, empty env, defaults, required, bad file, disabled-by-default, and prefix
- [x] Example test for godoc
- [x] Full test suite with race detector and 100% coverage