### PR TITLE
docs: document that an empty env var falls back to envDefault

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ You can see the full documentation and list of examples at [pkg.go.dev](https://
 > _Unexported fields_ will be **ignored** by `env`.
 > This is by design and will not change.
 
+> [!IMPORTANT]
+>
+> If a field declares an `envDefault`, a variable that is **set to an empty
+> value** is handled the same way as a variable that is **not set at all**: the
+> default value is used, and neither `required` nor `notEmpty` guards against
+> it.
+>
+> `env` cannot tell a variable that is explicitly set to an empty value from one
+> that is unset, so if that difference matters for a field, leave out the
+> `envDefault` and check `os.LookupEnv` yourself before applying a fallback.
+> See the [runnable example](https://pkg.go.dev/github.com/caarlos0/env/v11#example-Parse-EmptyValue).
+
 ### Functions
 
 - `Parse`: parse the current environment into a type
@@ -93,7 +105,8 @@ You may also add custom parsers for your types.
 The following tags are provided:
 
 - `env`: sets the environment variable name and optionally takes the tag options described below
-- `envDefault`: sets the default value for the field
+- `envDefault`: sets the default value for the field, also used when the
+  variable is set but empty (see [Caveats](#caveats))
 - `envPrefix`: can be used in a field that is a complex type to set a prefix to all environment variables used in it
 - `envSeparator`: sets the character to be used to separate items in slices and maps (default: `,`)
 - `envKeyValSeparator`: sets the character to be used to separate keys and their values in maps (default: `:`)

--- a/example_test.go
+++ b/example_test.go
@@ -174,6 +174,34 @@ func ExampleParse_setDefaults() {
 	// Output: {Foo:foo Bar:bar}
 }
 
+// If a field declares an `envDefault`, a variable that is set to an empty value
+// is handled the same way as a variable that is not set at all: the default
+// value is used.
+//
+// Neither `required` nor `notEmpty` guards against this: `required` is already
+// satisfied by the default, and `notEmpty` only sees the value after the
+// default was applied.
+//
+// `env` cannot tell a variable that is explicitly set to an empty value from
+// one that is unset, so if that difference matters for a field, leave out the
+// `envDefault` and check `os.LookupEnv` yourself before applying a fallback.
+func ExampleParse_emptyValue() {
+	type Config struct {
+		Foo string `env:"EMPTY_FOO" envDefault:"foo"`
+		Bar string `env:"EMPTY_BAR,notEmpty" envDefault:"bar"`
+		Baz string `env:"EMPTY_BAZ,required" envDefault:"baz"`
+	}
+	os.Setenv("EMPTY_FOO", "")
+	os.Setenv("EMPTY_BAR", "")
+	os.Setenv("EMPTY_BAZ", "")
+	var cfg Config
+	if err := Parse(&cfg); err != nil {
+		fmt.Println(err)
+	}
+	fmt.Printf("%+v", cfg)
+	// Output: {Foo:foo Bar:bar Baz:baz}
+}
+
 // You might want to listen to value sets and, for example, log something or do
 // some other kind of logic.
 func ExampleParseWithOptions_onSet() {


### PR DESCRIPTION
`envDefault` is documented as "sets the default value for the field", which
doesn't mention that a variable *set to an empty value* gets the default too —
the behavior introduced in #248 and released in v7.0.0.

It is easy to miss, because neither `required` nor `notEmpty` guards against it:
`required` is already satisfied by the default, and `notEmpty` only sees the
value after the default was applied.

No behavior changes, just documentation of what already happens:

- a note in the Caveats section, next to the unexported-fields one
- a pointer on the `envDefault` bullet
- a runnable example, so the claim is covered by `go test` and shows up on
  pkg.go.dev

Judging by #245 and #406, this keeps coming up.