### PR TITLE
docs: document that an empty env var falls back to envDefault

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ You can see the full documentation and list of examples at [pkg.go.dev](https://
 > _Unexported fields_ will be **ignored** by `env`.
 > This is by design and will not change.
 
+> [!CAUTION]
+>
+> An environment variable that is set but _empty_ will fall back to the
+> `envDefault` value, if any. Neither `required` nor `notEmpty` guard against
+> this: `required` is satisfied by the default, while `notEmpty` only sees the
+> value after the default has been applied.
+
 ### Functions
 
 - `Parse`: parse the current environment into a type
@@ -93,7 +100,7 @@ You may also add custom parsers for your types.
 The following tags are provided:
 
 - `env`: sets the environment variable name and optionally takes the tag options described below
-- `envDefault`: sets the default value for the field
+- `envDefault`: sets the default value for the field (also used when the environment variable is set but empty)
 - `envPrefix`: can be used in a field that is a complex type to set a prefix to all environment variables used in it
 - `envSeparator`: sets the character to be used to separate items in slices and maps (default: `,`)
 - `envKeyValSeparator`: sets the character to be used to separate keys and their values in maps (default: `:`)

--- a/example_test.go
+++ b/example_test.go
@@ -480,3 +480,17 @@ func Example_setDefaultsForZeroValuesOnly() {
 	// Without SetDefaultsForZeroValuesOnly, the username would have been 'admin'.
 	// Output: {Username:root Password:qwerty}
 }
+
+// An environment variable that is set but empty falls back to envDefault.
+func Example_parseEmptyEnvFallsBackToDefault() {
+	type Config struct {
+		Foo string `env:"FOO" envDefault:"fallback"`
+	}
+
+	os.Setenv("FOO", "")
+
+	cfg, _ := ParseAs[Config]()
+
+	fmt.Println(cfg.Foo)
+	// Output: fallback
+}


### PR DESCRIPTION
Fixes #428.

`envDefault` is documented as "sets the default value for the field", but a
variable *set to an empty value* also gets the default (behavior introduced in
#248, v7.0.0).

Adds:
- a note in the Caveats section
- a pointer on the `envDefault` bullet
- a runnable example, covered by `go test` and shown on pkg.go.dev

No behavior changes.