### PR TITLE
feat: add notEmptyIfDefined tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Here are all the options available for the `env` tag:
 - `,file`: instructs that the content of the variable is a path to a file that should be read
 - `,init`: initialize nil pointers
 - `,notEmpty`: make the field errors if the environment variable is empty
+- `,notEmptyIfDefined`: make the field errors if the environment variable is defined but empty (unset falls through to `envDefault`)
 - `,required`: make the field errors if the environment variable is not set
 - `,unset`: unset the environment variable after use
 

--- a/env.go
+++ b/env.go
@@ -534,17 +534,18 @@ func toEnvName(input string) string {
 
 // FieldParams contains information about parsed field tags.
 type FieldParams struct {
-	OwnKey          string
-	Key             string
-	DefaultValue    string
-	HasDefaultValue bool
-	Required        bool
-	LoadFile        bool
-	Unset           bool
-	NotEmpty        bool
-	Expand          bool
-	Init            bool
-	Ignored         bool
+	OwnKey            string
+	Key               string
+	DefaultValue      string
+	HasDefaultValue   bool
+	Required          bool
+	LoadFile          bool
+	Unset             bool
+	NotEmpty          bool
+	NotEmptyIfDefined bool
+	Expand            bool
+	Init              bool
+	Ignored           bool
 }
 
 func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, error) {
@@ -576,6 +577,8 @@ func parseFieldParams(field reflect.StructField, opts Options) (FieldParams, err
 			result.Unset = true
 		case "notEmpty":
 			result.NotEmpty = true
+		case "notEmptyIfDefined":
+			result.NotEmptyIfDefined = true
 		case "expand":
 			result.Expand = true
 		case "init":
@@ -616,6 +619,12 @@ func get(fieldParams FieldParams, opts Options) (val string, err error) {
 
 	if fieldParams.NotEmpty && val == "" {
 		return "", newEmptyVarError(fieldParams.Key)
+	}
+
+	if fieldParams.NotEmptyIfDefined {
+		if raw, defined := opts.Environment[fieldParams.Key]; defined && raw == "" {
+			return "", newEmptyVarError(fieldParams.Key)
+		}
 	}
 
 	if fieldParams.LoadFile && val != "" {

--- a/env_test.go
+++ b/env_test.go
@@ -1757,16 +1757,17 @@ func TestErrorIs(t *testing.T) {
 }
 
 type FieldParamsConfig struct {
-	Simple         []string `env:"SIMPLE"`
-	WithoutEnv     string
-	privateWithEnv string `env:"PRIVATE_WITH_ENV"` //nolint:unused
-	WithDefault    string `env:"WITH_DEFAULT" envDefault:"default"`
-	Required       string `env:"REQUIRED,required"`
-	File           string `env:"FILE,file"`
-	Unset          string `env:"UNSET,unset"`
-	NotEmpty       string `env:"NOT_EMPTY,notEmpty"`
-	Expand         string `env:"EXPAND,expand"`
-	NestedConfig   struct {
+	Simple            []string `env:"SIMPLE"`
+	WithoutEnv        string
+	privateWithEnv    string `env:"PRIVATE_WITH_ENV"` //nolint:unused
+	WithDefault       string `env:"WITH_DEFAULT" envDefault:"default"`
+	Required          string `env:"REQUIRED,required"`
+	File              string `env:"FILE,file"`
+	Unset             string `env:"UNSET,unset"`
+	NotEmpty          string `env:"NOT_EMPTY,notEmpty"`
+	NotEmptyIfDefined string `env:"NOT_EMPTY_IF_DEFINED,notEmptyIfDefined"`
+	Expand            string `env:"EXPAND,expand"`
+	NestedConfig      struct {
 		Simple []string `env:"SIMPLE"`
 	} `envPrefix:"NESTED_"`
 }
@@ -1783,6 +1784,7 @@ func TestGetFieldParams(t *testing.T) {
 		{OwnKey: "FILE", Key: "FILE", LoadFile: true},
 		{OwnKey: "UNSET", Key: "UNSET", Unset: true},
 		{OwnKey: "NOT_EMPTY", Key: "NOT_EMPTY", NotEmpty: true},
+		{OwnKey: "NOT_EMPTY_IF_DEFINED", Key: "NOT_EMPTY_IF_DEFINED", NotEmptyIfDefined: true},
 		{OwnKey: "EXPAND", Key: "EXPAND", Expand: true},
 		{OwnKey: "SIMPLE", Key: "NESTED_SIMPLE"},
 	}
@@ -1803,6 +1805,7 @@ func TestGetFieldParamsWithPrefix(t *testing.T) {
 		{OwnKey: "FILE", Key: "FOO_FILE", LoadFile: true},
 		{OwnKey: "UNSET", Key: "FOO_UNSET", Unset: true},
 		{OwnKey: "NOT_EMPTY", Key: "FOO_NOT_EMPTY", NotEmpty: true},
+		{OwnKey: "NOT_EMPTY_IF_DEFINED", Key: "FOO_NOT_EMPTY_IF_DEFINED", NotEmptyIfDefined: true},
 		{OwnKey: "EXPAND", Key: "FOO_EXPAND", Expand: true},
 		{OwnKey: "SIMPLE", Key: "FOO_NESTED_SIMPLE"},
 	}
@@ -2416,4 +2419,43 @@ func TestEnvBleed(t *testing.T) {
 		isNoErr(t, ParseWithOptions(&cfg, Options{Environment: map[string]string{"BAR": "202"}}))
 		isEqual(t, "", cfg.Foo)
 	})
+}
+
+func TestNotEmptyIfDefinedSetEmpty(t *testing.T) {
+	t.Setenv("IS_REQUIRED", "")
+	type config struct {
+		IsRequired string `env:"IS_REQUIRED,notEmptyIfDefined"`
+	}
+	err := Parse(&config{})
+	isErrorWithMessage(t, err, `env: environment variable "IS_REQUIRED" should not be empty`)
+	isTrue(t, errors.Is(err, EmptyVarError{}))
+}
+
+func TestNotEmptyIfDefinedSetEmptyWithDefault(t *testing.T) {
+	t.Setenv("IS_REQUIRED", "")
+	type config struct {
+		IsRequired string `env:"IS_REQUIRED,notEmptyIfDefined" envDefault:"important"`
+	}
+	err := Parse(&config{})
+	isErrorWithMessage(t, err, `env: environment variable "IS_REQUIRED" should not be empty`)
+	isTrue(t, errors.Is(err, EmptyVarError{}))
+}
+
+func TestNotEmptyIfDefinedNotSetWithDefault(t *testing.T) {
+	type config struct {
+		IsRequired string `env:"IS_REQUIRED,notEmptyIfDefined" envDefault:"important"`
+	}
+	cfg := &config{}
+	isNoErr(t, Parse(cfg))
+	isEqual(t, "important", cfg.IsRequired)
+}
+
+func TestNotEmptyIfDefinedSetValue(t *testing.T) {
+	t.Setenv("IS_REQUIRED", "value")
+	type config struct {
+		IsRequired string `env:"IS_REQUIRED,notEmptyIfDefined"`
+	}
+	cfg := &config{}
+	isNoErr(t, Parse(cfg))
+	isEqual(t, "value", cfg.IsRequired)
 }


### PR DESCRIPTION
Closes #376. Adds a `,notEmptyIfDefined` tag option that errors only when the environment variable is defined but empty; unset variables still fall through to `envDefault`. Includes tests and README docs.