### PR TITLE
docs: note that env cannot distinguish an empty variable from an unset one

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ You can see the full documentation and list of examples at [pkg.go.dev](https://
 > `envDefault` value, if any. Neither `required` nor `notEmpty` guard against
 > this: `required` is satisfied by the default, while `notEmpty` only sees the
 > value after the default has been applied.
+>
+> With an `envDefault` in place, `env` cannot tell a variable that is set to an
+> empty value from one that is not set at all. If that difference matters for a
+> field, leave out the `envDefault`: `notEmpty` then rejects the empty value,
+> and `os.LookupEnv` lets you apply a fallback only when the variable is really
+> unset.
 
 ### Functions
 

--- a/example_test.go
+++ b/example_test.go
@@ -482,15 +482,26 @@ func Example_setDefaultsForZeroValuesOnly() {
 }
 
 // An environment variable that is set but empty falls back to envDefault.
+//
+// Neither `required` nor `notEmpty` guards against this: `required` is already
+// satisfied by the default, and `notEmpty` only sees the value after the
+// default was applied.
 func Example_parseEmptyEnvFallsBackToDefault() {
 	type Config struct {
-		Foo string `env:"FOO" envDefault:"fallback"`
+		Foo string `env:"EMPTY_FOO" envDefault:"fallback"`
+		Bar string `env:"EMPTY_BAR,notEmpty" envDefault:"fallback"`
+		Baz string `env:"EMPTY_BAZ,required" envDefault:"fallback"`
 	}
 
-	os.Setenv("FOO", "")
+	os.Setenv("EMPTY_FOO", "")
+	os.Setenv("EMPTY_BAR", "")
+	os.Setenv("EMPTY_BAZ", "")
 
-	cfg, _ := ParseAs[Config]()
+	cfg, err := ParseAs[Config]()
+	if err != nil {
+		fmt.Println(err)
+	}
 
-	fmt.Println(cfg.Foo)
-	// Output: fallback
+	fmt.Printf("%+v", cfg)
+	// Output: {Foo:fallback Bar:fallback Baz:fallback}
 }


### PR DESCRIPTION
Follow-up to #432, which landed the caveat that was originally proposed in #428.

Two things are still missing:

**What to do about it.** `getOr` returns `(defaultValue, exists=true, isDefault=true)` for a variable that is set but empty:

```go
case exists && value == "" && defExists:
	return defaultValue, true, true
```

So with an `envDefault` in place, the two cases are indistinguishable. A field
that needs to tell them apart has to leave the default out and either use
`notEmpty`, which then rejects the empty value, or check `os.LookupEnv` before
applying a fallback. The Caveats note now says so.

**The `required`/`notEmpty` trap is asserted, but nothing checks it.** The
README states it; no test covers it. `Example_parseEmptyEnvFallsBackToDefault`
now covers all three cases instead of the plain fallback only, so `go test`
verifies the claim and it shows up on pkg.go.dev.

The example's variables are renamed to `EMPTY_*`, since `FOO` is also set by
other examples in this package.

No behavior changes.